### PR TITLE
Fix readme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $type = $node->getType();
 $path = $node->getPath();
 ```
 
-Comprehensive API documentation is available [here](https://coveralls.io/github/baacode/json-browser).
+Comprehensive API documentation is available [here](https://baacode.github.io/json-browser/).
 
 Installation
 ------------


### PR DESCRIPTION
## What
Fix link to API docs in README.md

## Why
Because the link is wrong.