### PR TITLE
Make JsonBrowser traversable

### DIFF
--- a/src/Iterator.php
+++ b/src/Iterator.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace JsonBrowser;
+
+/**
+ * Iterate through child nodes
+ *
+ * @since 1.3.0
+ *
+ * @package baacode/json-browser
+ * @copyright (c) 2017 Erayd LTD
+ * @author Steve Gilberd <steve@erayd.net>
+ * @license ISC
+ */
+class Iterator implements \Iterator
+{
+    /** Chained iterator */
+    private $iterator = null;
+
+    /** Browser instance */
+    private $browser = null;
+
+    /**
+     * Create a new instance
+     *
+     * @since 1.3.0
+     *
+     * @param JsonBrowser $browser
+     */
+    public function __construct(JsonBrowser $browser)
+    {
+        $this->browser = $browser;
+
+        $type = $browser->getType();
+        if ($type & (JsonBrowser::TYPE_ARRAY | JsonBrowser::TYPE_OBJECT)) {
+            $this->iterator = new \ArrayIterator($browser->getValue(), 0);
+        } else {
+            $this->iterator = new \EmptyIterator();
+        }
+    }
+
+    /**
+     * Get a browser object for the current child
+     *
+     * @since 1.3.0
+     *
+     * @return JsonBrowser
+     */
+    public function current() : JsonBrowser
+    {
+        return $this->browser->getChild($this->iterator->key());
+    }
+
+    /**
+     * Get the current child index
+     *
+     * @since 1.3.0
+     *
+     * @return mixed
+     */
+    public function key()
+    {
+        return $this->iterator->key();
+    }
+
+    /**
+     * Advance the internal pointer to the next child
+     *
+     * @since 1.3.0
+     *
+     */
+    public function next()
+    {
+        return $this->iterator->next();
+    }
+
+    /**
+     * Reset the internal pointer to the first child
+     *
+     * @since 1.3.0
+     *
+     */
+    public function rewind()
+    {
+        return $this->iterator->rewind();
+    }
+
+    /**
+     * Test whether there are more children to iterate over
+     *
+     * @since 1.3.0
+     *
+     * @return bool
+     */
+    public function valid() : bool
+    {
+        return $this->iterator->valid();
+    }
+}

--- a/src/JsonBrowser.php
+++ b/src/JsonBrowser.php
@@ -14,7 +14,7 @@ use Seld\JsonLint\JsonParser;
  * @author Steve Gilberd <steve@erayd.net>
  * @license ISC
  */
-class JsonBrowser
+class JsonBrowser implements \IteratorAggregate
 {
     /** Throw exceptions instead of using NULL for nonexistent children & siblings */
     const OPT_NONEXISTENT_EXCEPTIONS = 1;
@@ -325,5 +325,17 @@ class JsonBrowser
     public function getValueAt(string $path)
     {
         return $this->getNodeAt($path)->getValue();
+    }
+
+    /**
+     * Get an iterator handle
+     *
+     * @since 1.3.0
+     *
+     * @return Traversable Iterator instance
+     */
+    public function getIterator()
+    {
+        return new Iterator($this);
     }
 }

--- a/tests/IteratorTest.php
+++ b/tests/IteratorTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace JsonBrowser\Tests;
+
+use JsonBrowser\JsonBrowser;
+use JsonBrowser\Exception;
+
+class IteratorTest extends \PHPUnit\Framework\TestCase
+{
+    public function testEmpty()
+    {
+        $browser = new JsonBrowser('"notAContainer"');
+
+        foreach ($browser as $child) {
+            $this->assertTrue(false); // should never execute
+        }
+        $this->assertNull($child ?? null);
+    }
+
+    public function testArray()
+    {
+        $browser = new JsonBrowser('["valueOne", "valueTwo"]');
+        $count = 0;
+        foreach ($browser as $key => $child) {
+            $this->assertEquals($count++, $key);
+            $this->assertInstanceOf(JsonBrowser::class, $child);
+            if ($count == 1) {
+                $this->assertEquals('valueOne', $child->getValue());
+            } else {
+                $this->assertEquals('valueTwo', $child->getValue());
+            }
+        }
+        $this->assertEquals(2, $count);
+    }
+
+    public function testObject()
+    {
+        $browser = new JsonBrowser('{"childOne": "valueOne", "childTwo": {"childThree": "valueThree"}}');
+
+        $count = 0;
+        foreach ($browser as $key => $child) {
+            $this->assertInstanceOf(JsonBrowser::class, $child);
+            if (++$count == 1) {
+                $this->assertEquals('childOne', $key);
+                $this->assertEquals('valueOne', $child->getValue());
+            } else {
+                $this->assertEquals('childTwo', $key);
+                $this->assertEquals((object)['childThree' => 'valueThree'], $child->getValue());
+            }
+        }
+        $this->assertEquals(2, $count);
+    }
+}


### PR DESCRIPTION
## What
Add iterator to `JsonBrowser` in order to make it traversable by `foreach` etc.

## Why
Because sometimes it's desirable to iterate through the children without necessarily knowing in advance which children are present, or without wanting to implement the mechanics of an iterator loop.