### PR TITLE
Add JsonBrowser::nodeExists()

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ $path = $node->getPath();
 
 // get JSON source for node
 $json = $node->getJSON();
+
+// check whether current node exists
+$nodeExists = $node->nodeExists();
+
 ```
 
 Documentation

--- a/src/JsonBrowser.php
+++ b/src/JsonBrowser.php
@@ -70,6 +70,9 @@ class JsonBrowser implements \IteratorAggregate
     /** Node key */
     private $key = null;
 
+    /** Whether this node exists */
+    private $exists = true;
+
     /**
      * Create a new instance
      *
@@ -142,6 +145,7 @@ class JsonBrowser implements \IteratorAggregate
             }
             $child = clone $this;
             $child->document = null;
+            $child->exists = false;
         } else {
             $child = clone $this;
             if (is_array($this->document)) {
@@ -384,6 +388,18 @@ class JsonBrowser implements \IteratorAggregate
             return ($this->getType() & $types) == $types;
         }
         return (bool)($this->getType() & $types);
+    }
+
+    /**
+     * Check whether the current node exists in the parent document
+     *
+     * @since 1.4.0
+     *
+     * @return bool
+     */
+    public function nodeExists() : bool
+    {
+        return $this->exists;
     }
 
     /**

--- a/tests/CreateTest.php
+++ b/tests/CreateTest.php
@@ -40,4 +40,15 @@ class CreateTest extends \PHPUnit\Framework\TestCase
             $this->assertEquals(json_decode($json), $browser->getValue());
         }
     }
+
+    public function testExists()
+    {
+        $browser = new JsonBrowser('{"propertyOne": {"propertyTwo": "valueTwo"}}');
+
+        $this->assertTrue($browser->getNodeAt('#/propertyOne')->nodeExists());
+        $this->assertFalse($browser->getNodeAt('#/propertyThree')->nodeExists());
+        $this->assertTrue($browser->getNodeAt('#/propertyOne/propertyTwo')->nodeExists());
+        $this->assertFalse($browser->getNodeAt('#/propertyOne/propertyThree')->nodeExists());
+        $this->assertFalse($browser->getNodeAt('#/propertyOne/propertyThree/propertyFour')->nodeExists());
+    }
 }


### PR DESCRIPTION
## What
Add JsonBrowser::nodeExists().

## Why
Because NULL nodes may still be returned in non-exception mode, but may not represent actual data in the underlying document. This method allows the user to distinguish between an actual NULL value, and a value that is undefined.