### PR TITLE
Refactor to make it easier to add new functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ $value = $browser->getValueAt('#/childName/grandchildName/4');
 // set arbitrary node value by path
 $browser->setValueAt('#/childName/grandchildName/4', 'myValue')
 
+// delete arbitrary node value by path
+$browser->deleteValueAt('#/childName/grandchildName/4')
+
 // get root node
 $root = $node->getRoot();
 
@@ -54,6 +57,9 @@ $value = $node->getValue();
 
 // set node value
 $node->setValue('myValue');
+
+// delete node value
+$node->deleteValue();
 
 // get node type
 $type = $node->getType();

--- a/src/Context.php
+++ b/src/Context.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace JsonBrowser;
+
+use Seld\JsonLint\JsonParser;
+
+/**
+ * Document context
+ *
+ * @since 1.5.0
+ *
+ * @package baacode/json-browser
+ * @copyright (c) 2017-2018 Erayd LTD
+ * @author Steve Gilberd <steve@erayd.net>
+ * @license ISC
+ */
+class Context
+{
+    /** Configuration options */
+    private $options = 0;
+
+    /** Root JsonBrowser object */
+    private $root = null;
+    
+    /** Decoded JSON document */
+    private $document = null;
+
+    /**
+     * Create a new instance
+     *
+     * @since 1.5.0
+     *
+     * @param JsonBrowser   $root       JsonBrowser for root node
+     * @param string        $json       JSON-encoded data
+     * @param int           $options    Configuration options (bitmask)
+     */
+    public function __construct(JsonBrowser $root, string $json, int $options = 0)
+    {
+        // set root
+        $this->root = $root;
+
+        // set options
+        $this->options = $options;
+
+        // decode document
+        Exception::wrap(function () use ($json) {
+            try {
+                // decode via json_decode for speed
+                $this->document = json_decode($json);
+                if (json_last_error() != \JSON_ERROR_NONE) {
+                    throw new \Exception(json_last_error_msg(), json_last_error());
+                }
+            } catch (\Throwable $e) {
+                // if decoding fails, then lint using JsonParser
+                $parser = new JsonParser();
+                if (!is_null($parserException = $parser->lint($json))) {
+                    throw $parserException;
+                }
+                // if JsonParser can decode successfully, but json_decode() cannot, complain loudly
+                throw new \Exception('Unknown JSON decoding error'); // @codeCoverageIgnore
+            }
+        }, JsonBrowser::ERR_DECODING_ERROR, 'Unable to decode JSON data: %s');
+    }
+
+    /**
+     * Check whether the value at a given path exists
+     *
+     * @since 1.5.0
+     *
+     * @param array $path Array of path elements
+     * @return bool Whether a value exists at the given path
+     */
+    public function valueExists(array $path) : bool
+    {
+        $this->getValue($path, $exists);
+        return $exists;
+    }
+
+    /**
+     * Get the value at a given path
+     *
+     * @since 1.5.0
+     *
+     * @param array $path Array of path elements
+     * @param bool Reference - set to true if the value exists, false otherwise
+     * @return mixed|null Value data, or null if value does not exist
+     */
+    public function getValue(array $path, bool &$exists = null)
+    {
+        $target = $this->document;
+
+        // follow path to conclusion or return null if not found
+        while (count($path)) {
+            $element = array_shift($path);
+            if (is_array($target) && array_key_exists($element, $target)) {
+                $target = $target[$element];
+            } elseif (is_object($target) && property_exists($target, $element)) {
+                $target = $target->$element;
+            } else {
+                $exists = false;
+                return null;
+            }
+        }
+
+        $exists = true;
+        return $target;
+    }
+
+    /**
+     * Set the value at a given path
+     *
+     * @since 1.5.0
+     *
+     * @param array $path Array of path elements
+     * @param mixed $value Value data to set
+     * @param bool  $padSparseArray Whether to left-pad sparse arrays with null values
+     */
+    public function setValue(array $path, $value, bool $padSparseArray = false)
+    {
+        $target = &$this->document;
+
+        // follow path to conclusion and create missing elements
+        while (count($path)) {
+            $element = array_shift($path);
+            // promote null to array
+            if (is_null($target)) {
+                $target = [];
+            }
+
+            // promote array to object if element is not an integer array key
+            if (is_array($target) && !(is_numeric($element) && $element == floor($element))) {
+                $target = (object)$target;
+            }
+
+            // step into child element
+            if (is_array($target)) {
+                // left-pad array with nulls
+                if ($padSparseArray) {
+                    for ($i = 0; $i < $element; $i++) {
+                        if (!array_key_exists($element, $target)) {
+                            $target[$i] = null;
+                        }
+                    }
+                }
+                if (!array_key_exists($element, $target)) {
+                    $target[$element] = [];
+                }
+                $target = &$target[$element];
+            } elseif (is_object($target)) {
+                if (!property_exists($target, $element)) {
+                    $target->$element = [];
+                }
+                $target = &$target->$element;
+            } else {
+                throw new Exception(
+                    JsonBrowser::ERR_INVALID_CONTAINER_TYPE,
+                    'Invalid container type: %s',
+                    gettype($target)
+                );
+            }
+        }
+
+        // set value of target
+        $target = $value;
+    }
+}

--- a/src/Context.php
+++ b/src/Context.php
@@ -122,15 +122,7 @@ class Context
         // follow path to conclusion and create missing elements
         while (count($path)) {
             $element = array_shift($path);
-            // promote null to array
-            if (is_null($target)) {
-                $target = [];
-            }
-
-            // promote array to object if element is not an integer array key
-            if (is_array($target) && !(is_numeric($element) && $element == floor($element))) {
-                $target = (object)$target;
-            }
+            $this->promoteContainer($target, $element);
 
             // step into child element
             if (is_array($target)) {
@@ -162,5 +154,26 @@ class Context
 
         // set value of target
         $target = $value;
+    }
+
+    /**
+     * Promote container type as necessary to hold a child key
+     *
+     * @since 1.5.0
+     *
+     * @param mixed $container  Target container
+     * @param mixed $key        Intended key
+     */
+    private function promoteContainer(&$container, $key)
+    {
+        // promote null to array
+        if (is_null($container)) {
+            $container = [];
+        }
+
+        // promote array to object if the key is not an integer
+        if (is_array($container) && !(is_numeric($key) && $key == floor($key))) {
+            $container = (object)$container;
+        }
     }
 }

--- a/src/Context.php
+++ b/src/Context.php
@@ -157,6 +157,44 @@ class Context
     }
 
     /**
+     * Delete the value at a given path
+     *
+     * @since 1.5.0
+     *
+     * @param array $path        Array of path elements
+     * @param bool  $deleteEmpty Whether to delete empty containers
+     */
+    public function deleteValue(array $path, bool $deleteEmpty = false)
+    {
+        $target = $this->document;
+        $containerPath = [];
+
+        // follow path to conclusion or return early if not found
+        while (count($path) > 1) {
+            $element = $containerPath[] = array_shift($path);
+            if (is_array($target) && array_key_exists($element, $target)) {
+                $target = $target[$element];
+            } elseif (is_object($target) && property_exists($target, $element)) {
+                $target = $target->$element;
+            } else {
+                return;
+            }
+        }
+
+        // unset the child element
+        if (is_array($target)) {
+            unset($target[array_shift($path)]);
+        } elseif (is_object($target)) {
+            unset($target->{array_shift($path)});
+        }
+
+        // recurse to delete empty containers
+        if ($deleteEmpty && !count((array)$target)) {
+            $this->deleteValue($containerPath, $deleteEmpty);
+        }
+    }
+
+    /**
      * Promote container type as necessary to hold a child key
      *
      * @since 1.5.0

--- a/src/Context.php
+++ b/src/Context.php
@@ -166,31 +166,36 @@ class Context
      */
     public function deleteValue(array $path, bool $deleteEmpty = false)
     {
-        $target = $this->document;
+        $target = &$this->document;
         $containerPath = [];
 
         // follow path to conclusion or return early if not found
         while (count($path) > 1) {
             $element = $containerPath[] = array_shift($path);
             if (is_array($target) && array_key_exists($element, $target)) {
-                $target = $target[$element];
+                $target = &$target[$element];
             } elseif (is_object($target) && property_exists($target, $element)) {
-                $target = $target->$element;
+                $target = &$target->$element;
             } else {
                 return;
             }
         }
 
-        // unset the child element
-        if (is_array($target)) {
-            unset($target[array_shift($path)]);
-        } elseif (is_object($target)) {
-            unset($target->{array_shift($path)});
-        }
+        if (count($path)) {
+            // unset the child element
+            if (is_array($target)) {
+                unset($target[array_shift($path)]);
+            } elseif (is_object($target)) {
+                unset($target->{array_shift($path)});
+            }
 
-        // recurse to delete empty containers
-        if ($deleteEmpty && !count((array)$target)) {
-            $this->deleteValue($containerPath, $deleteEmpty);
+            // recurse to delete empty containers
+            if ($deleteEmpty && !count((array)$target)) {
+                $this->deleteValue($containerPath, $deleteEmpty);
+            }
+        } else {
+            // we're at the root, so set the target to null rather than unsetting it
+            $target = null;
         }
     }
 

--- a/src/JsonBrowser.php
+++ b/src/JsonBrowser.php
@@ -181,6 +181,10 @@ class JsonBrowser implements \IteratorAggregate
         $node = clone $this;
         $node->path = Util::decodePointer($path);
 
+        if (($this->options & self::OPT_NONEXISTENT_EXCEPTIONS) && !$node->nodeExists()) {
+            throw new Exception(self::ERR_UNKNOWN_TARGET, 'Target node is unknown: %s', $path);
+        }
+
         return $node;
     }
 
@@ -414,7 +418,7 @@ class JsonBrowser implements \IteratorAggregate
      */
     public function setValueAt(string $path, $value, bool $padSparseArray = false)
     {
-        return $this->getNodeAt($path)->setValue($value, $padSparseArray);
+        return $this->context->setValue(Util::decodePointer($path), $value, $padSparseArray);
     }
 
     /**

--- a/src/JsonBrowser.php
+++ b/src/JsonBrowser.php
@@ -112,6 +112,19 @@ class JsonBrowser implements \IteratorAggregate
     }
 
     /**
+     * Delete the value at a given path
+     *
+     * @since 1.5.0
+     *
+     * @param string $path JSON pointer to the node that should be deleted
+     * @param bool $deleteEmpty Whether to delete empty containers
+     */
+    public function deleteValueAt(string $path, bool $deleteEmpty = false)
+    {
+        $this->context->deleteValue(Util::decodePointer($path), $deleteEmpty);
+    }
+
+    /**
      * Get a child node
      *
      * @since 1.0.0

--- a/src/JsonBrowser.php
+++ b/src/JsonBrowser.php
@@ -100,6 +100,18 @@ class JsonBrowser implements \IteratorAggregate
     }
 
     /**
+     * Delete the current node value
+     *
+     * @since 1.5.0
+     *
+     * @param bool $deleteEmpty Whether to delete empty containers
+     */
+    public function deleteValue(bool $deleteEmpty = false)
+    {
+        $this->context->deleteValue($this->path, $deleteEmpty);
+    }
+
+    /**
      * Get a child node
      *
      * @since 1.0.0

--- a/src/Util.php
+++ b/src/Util.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace JsonBrowser;
+
+/**
+ * Static utility methods
+ *
+ * @since 1.5.0
+ *
+ * @package baacode/json-browser
+ * @copyright (c) 2017-2018 Erayd LTD
+ * @author Steve Gilberd <steve@erayd.net>
+ * @license ISC
+ */
+abstract class Util
+{
+    /**
+     * Decode a JSON pointer to a path array
+     *
+     * @since 1.5.0
+     *
+     * @param string $pointer JSON pointer
+     * @return array Array of path elements
+     */
+    public static function decodePointer(string $pointer) : array
+    {
+        // root pointer is an empty array, *not* an array with one empty element
+        if ($pointer == '#/') {
+            return [];
+        }
+
+        // explode path portion of pointer and translate each element
+        return array_map(function ($element) {
+            return strtr($element, ['%25' => '%', '~1' => '/', '~0' => '~']);
+        }, explode('/', substr($pointer, 2)));
+    }
+
+    /**
+     * Encode a path array as a JSON pointer
+     *
+     * @since 1.5.0
+     *
+     * @param array $path Array of path elements
+     * @return string JSON pointer
+     */
+    public static function encodePointer(array $path) : string
+    {
+        // translate each element of path & implode to pointer
+        return '#/' . implode('/', array_map(function ($element) {
+            return strtr($element, ['~' => '~0', '/' => '~1', '%' => '%25']);
+        }, $path));
+    }
+
+    /**
+     * Recursively compare two values for equality
+     *
+     * @since 1.4.0 (formerly JsonBrowser::compare())
+     *
+     * @param mixed $valueOne
+     * @param mixed $valueTwo
+     * @return bool
+     */
+    public static function compare($valueOne, $valueTwo) : bool
+    {
+
+        // fast-path for type-equal (or instance-equal) values
+        if ($valueOne === $valueTwo) {
+            return true;
+        }
+
+        // recursive object comparison
+        if (is_object($valueOne) && is_object($valueTwo)) {
+            foreach ($valueOne as $pName => $pValue) {
+                if (!property_exists($valueTwo, $pName) || !self::compare($valueOne->$pName, $valueTwo->$pName)) {
+                    return false;
+                }
+            }
+            foreach ($valueTwo as $pName => $pValue) {
+                if (!property_exists($valueOne, $pName)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        // compare numeric types loosely, but don't accept numeric strings
+        if (!is_string($valueOne) && !is_string($valueTwo) && is_numeric($valueOne) && is_numeric($valueTwo)) {
+            return ($valueOne == $valueTwo);
+        }
+
+        // strict equality check failed
+        return false;
+    }
+}

--- a/src/Util.php
+++ b/src/Util.php
@@ -52,7 +52,7 @@ abstract class Util
     }
 
     /**
-     * Recursively compare two values for equality
+     * Compare two values for equality
      *
      * @since 1.4.0 (formerly JsonBrowser::compare())
      *
@@ -70,17 +70,7 @@ abstract class Util
 
         // recursive object comparison
         if (is_object($valueOne) && is_object($valueTwo)) {
-            foreach ($valueOne as $pName => $pValue) {
-                if (!property_exists($valueTwo, $pName) || !self::compare($valueOne->$pName, $valueTwo->$pName)) {
-                    return false;
-                }
-            }
-            foreach ($valueTwo as $pName => $pValue) {
-                if (!property_exists($valueOne, $pName)) {
-                    return false;
-                }
-            }
-            return true;
+            return self::compareObjects($valueOne, $valueTwo);
         }
 
         // compare numeric types loosely, but don't accept numeric strings
@@ -90,5 +80,29 @@ abstract class Util
 
         // strict equality check failed
         return false;
+    }
+
+    /**
+     * Recursively compare two objects for equality
+     *
+     * @since 1.5.0
+     *
+     * @param \StdClass $valueOne
+     * @param \StdClass $valueTwo
+     * @return bool
+     */
+    private static function compareObjects(\StdClass $valueOne, \StdClass $valueTwo)
+    {
+        foreach ($valueOne as $pName => $pValue) {
+            if (!property_exists($valueTwo, $pName) || !self::compare($valueOne->$pName, $valueTwo->$pName)) {
+                return false;
+            }
+        }
+        foreach ($valueTwo as $pName => $pValue) {
+            if (!property_exists($valueOne, $pName)) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/tests/ChildTest.php
+++ b/tests/ChildTest.php
@@ -75,4 +75,23 @@ class ChildTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($root, $childOne->getParent());
         $this->assertEquals($childOne, $childTwo->getParent());
     }
+
+    public function testDeletedChild()
+    {
+        $root = new JsonBrowser('{"childOne": ["valueOne"], "childTwo": {}}', JsonBrowser::OPT_NONEXISTENT_EXCEPTIONS);
+        $childOne = $root->getChild('childOne');
+        $gcOne = $childOne->getChild(0);
+        $childTwo = $root->getChild('childOne');
+
+        $this->assertTrue($gcOne->nodeExists());
+        $childOne->setValue('valueOne');
+        $this->assertFalse($gcOne->nodeExists());
+
+        $this->assertTrue($childTwo->nodeExists());
+        $childTwo->deleteValue();
+        $this->assertFalse($childTwo->nodeExists());
+
+        $this->expectException(Exception::class);
+        $childTwo->getValue();
+    }
 }

--- a/tests/ChildTest.php
+++ b/tests/ChildTest.php
@@ -75,23 +75,4 @@ class ChildTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($root, $childOne->getParent());
         $this->assertEquals($childOne, $childTwo->getParent());
     }
-
-    public function testDeletedChild()
-    {
-        $root = new JsonBrowser('{"childOne": ["valueOne"], "childTwo": {}}', JsonBrowser::OPT_NONEXISTENT_EXCEPTIONS);
-        $childOne = $root->getChild('childOne');
-        $gcOne = $childOne->getChild(0);
-        $childTwo = $root->getChild('childOne');
-
-        $this->assertTrue($gcOne->nodeExists());
-        $childOne->setValue('valueOne');
-        $this->assertFalse($gcOne->nodeExists());
-
-        $this->assertTrue($childTwo->nodeExists());
-        $childTwo->deleteValue();
-        $this->assertFalse($childTwo->nodeExists());
-
-        $this->expectException(Exception::class);
-        $childTwo->getValue();
-    }
 }

--- a/tests/PathTest.php
+++ b/tests/PathTest.php
@@ -24,6 +24,14 @@ class PathTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($root, $root->getNodeAt('#/'));
     }
 
+    public function testNodeByPathException()
+    {
+        $root = new JsonBrowser('{}', JsonBrowser::OPT_NONEXISTENT_EXCEPTIONS);
+
+        $this->expectException(Exception::class);
+        $root->getNodeAt('#/this/path/does/not/exist');
+    }
+
     public function testValueByPathException()
     {
         $root = new JsonBrowser('{}', JsonBrowser::OPT_NONEXISTENT_EXCEPTIONS);

--- a/tests/PathTest.php
+++ b/tests/PathTest.php
@@ -23,4 +23,12 @@ class PathTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals($root, $root->getNodeAt('#/'));
     }
+
+    public function testValueByPathException()
+    {
+        $root = new JsonBrowser('{}', JsonBrowser::OPT_NONEXISTENT_EXCEPTIONS);
+
+        $this->expectException(Exception::class);
+        $root->getValueAt('#/this/path/does/not/exist');
+    }
 }

--- a/tests/SetTest.php
+++ b/tests/SetTest.php
@@ -124,19 +124,6 @@ class SetTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('null', $root->getJSON(0));
     }
 
-    public function testRefresh()
-    {
-        $root = new JsonBrowser('{"childOne": "valueOne"}');
-        $childOne = $root->getChild('childOne');
-
-        $pre = $childOne->getValue();
-        $root->setValueAt('#/childOne', 'valueTwo');
-        $post = $childOne->getValue();
-
-        $this->assertSame('valueOne', $pre);
-        $this->assertSame('valueTwo', $post);
-    }
-
     public function testDeleteChildOfInvalidContainer()
     {
         $browser = new JsonBrowser('"this is a string"');

--- a/tests/SetTest.php
+++ b/tests/SetTest.php
@@ -136,4 +136,11 @@ class SetTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('valueOne', $pre);
         $this->assertSame('valueTwo', $post);
     }
+
+    public function testDeleteChildOfInvalidContainer()
+    {
+        $browser = new JsonBrowser('"this is a string"');
+        $browser->deleteValueAt('#/non/existent/path');
+        $this->assertEquals('"this is a string"', $browser->getJSON());
+    }
 }


### PR DESCRIPTION
## What
 - Move internal utility functions from `JsonBrowser` into new class `Util`.
 - Move the entire document context into new class `Context`, and require only a single instance of it.
 - Simplify instance-specific context of `JsonBrowser` down to a single path array

## Why
 - To make future modifications easier
 - To make browsing without interacting with the document less expensive