### PR TITLE
Add JsonBrowser::asRoot()

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ $path = $node->getPath();
 // get JSON source for node
 $json = $node->getJSON();
 
+// get a node as the root of a subtree
+$root = $node->asRoot();
+
 ```
 
 Configuration Options

--- a/src/Context.php
+++ b/src/Context.php
@@ -19,11 +19,11 @@ class Context
     /** Configuration options */
     private $options = 0;
 
-    /** Root JsonBrowser object */
-    private $root = null;
-    
     /** Decoded JSON document */
     private $document = null;
+
+    /** Path to root location in document */
+    private $path = [];
 
     /**
      * Create a new instance
@@ -34,11 +34,8 @@ class Context
      * @param string        $json       JSON-encoded data
      * @param int           $options    Configuration options (bitmask)
      */
-    public function __construct(JsonBrowser $root, string $json, int $options = 0)
+    public function __construct(string $json, int $options = 0)
     {
-        // set root
-        $this->root = $root;
-
         // set options
         $this->options = $options;
 
@@ -60,6 +57,20 @@ class Context
                 throw new \Exception('Unknown JSON decoding error'); // @codeCoverageIgnore
             }
         }, JsonBrowser::ERR_DECODING_ERROR, 'Unable to decode JSON data: %s');
+    }
+
+    /**
+     * Get a new context with the provided path as the root
+     *
+     * @param array $path Array of path elements
+     * @return self New context with $root as the document root
+     */
+    public function getSubtreeContext(array $path) : self
+    {
+        $subtree = clone $this;
+        $subtree->path = array_merge($this->path, $path);
+        
+        return $subtree;
     }
 
     /**
@@ -87,6 +98,7 @@ class Context
      */
     public function getValue(array $path, bool &$exists = null)
     {
+        $path = array_merge($this->path, $path);
         $target = $this->document;
 
         // follow path to conclusion or return null if not found
@@ -117,6 +129,7 @@ class Context
      */
     public function setValue(array $path, $value, bool $padSparseArray = false)
     {
+        $path = array_merge($this->path, $path);
         $target = &$this->document;
 
         // follow path to conclusion and create missing elements
@@ -166,6 +179,7 @@ class Context
      */
     public function deleteValue(array $path, bool $deleteEmpty = false)
     {
+        $path = array_merge($this->path, $path);
         $target = &$this->document;
         $containerPath = [];
 

--- a/src/Context.php
+++ b/src/Context.php
@@ -7,6 +7,7 @@ use Seld\JsonLint\JsonParser;
 /**
  * Document context
  *
+ * @internal
  * @since 1.5.0
  *
  * @package baacode/json-browser

--- a/src/JsonBrowser.php
+++ b/src/JsonBrowser.php
@@ -68,9 +68,6 @@ class JsonBrowser implements \IteratorAggregate
     /** Document context */
     private $context = null;
 
-    /** Root node */
-    private $root = null;
-
     /** Node path */
     private $path = [];
 
@@ -84,9 +81,8 @@ class JsonBrowser implements \IteratorAggregate
      */
     public function __construct(string $json, int $options = 0)
     {
-        $this->root = $this;
         $this->options = $options;
-        $this->context = new Context($this, $json, $options);
+        $this->context = new Context($json, $options);
     }
 
     /**
@@ -118,6 +114,22 @@ class JsonBrowser implements \IteratorAggregate
     public function __set($key, $value)
     {
         $this->context->setValue(array_merge($this->path, [$key]), $value);
+    }
+
+    /**
+     * Get the current node as a document root
+     *
+     * @since 1.6.0
+     *
+     * @return self A new JsonBrowser instance pointing to the current node
+     */
+    public function asRoot() : self
+    {
+        $root = clone $this;
+        $root->context = $this->context->getSubtreeContext($this->path);
+        $root->path = [];
+
+        return $root;
     }
 
     /**
@@ -276,7 +288,7 @@ class JsonBrowser implements \IteratorAggregate
      */
     public function getRoot() : self
     {
-        return $this->root;
+        return $this->getNodeAt('#/');
     }
 
     /**

--- a/src/Util.php
+++ b/src/Util.php
@@ -5,6 +5,7 @@ namespace JsonBrowser;
 /**
  * Static utility methods
  *
+ * @internal
  * @since 1.5.0
  *
  * @package baacode/json-browser

--- a/tests/RootTest.php
+++ b/tests/RootTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace JsonBrowser\Tests;
+
+use JsonBrowser\JsonBrowser;
+use JsonBrowser\Exception;
+
+class RootTest extends \PHPUnit\Framework\TestCase
+{
+    public function testChangeRoot()
+    {
+        $root = new JsonBrowser('{"childOne": {"childTwo": "valueTwo"}}');
+        $childOne = $root->getChild('childOne')->asRoot();
+
+        $this->assertEquals('{"childTwo":"valueTwo"}', $childOne->getJSON(0));
+        $this->assertEquals($childOne, $childOne->getRoot());
+        $this->assertEquals($childOne, $childOne->getNodeAt('#/'));
+
+        $childTwo = $childOne->getChild('childTwo')->asRoot();
+        $this->assertEquals('valueTwo', $childTwo->getValue());
+
+        $childTwo->setValue('valueThree');
+        $this->assertEquals('{"childOne":{"childTwo":"valueThree"}}', $root->getJSON(0));
+    }
+}


### PR DESCRIPTION
## What
 * Allows getting a node as the root of a subtree.

## Why
Because always interacting with the entire tree can sometimes be cumbersome.