### PR TITLE
Add ability to attach to existing document

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -2,8 +2,6 @@
 
 namespace JsonBrowser;
 
-use Seld\JsonLint\JsonParser;
-
 /**
  * Document context
  *
@@ -31,33 +29,13 @@ class Context
      *
      * @since 1.5.0
      *
-     * @param JsonBrowser   $root       JsonBrowser for root node
-     * @param string        $json       JSON-encoded data
+     * @param mixed         $document   Reference to the target document
      * @param int           $options    Configuration options (bitmask)
      */
-    public function __construct(string $json, int $options = 0)
+    public function __construct(&$document, int $options = 0)
     {
-        // set options
+        $this->document = &$document;
         $this->options = $options;
-
-        // decode document
-        Exception::wrap(function () use ($json) {
-            try {
-                // decode via json_decode for speed
-                $this->document = json_decode($json);
-                if (json_last_error() != \JSON_ERROR_NONE) {
-                    throw new \Exception(json_last_error_msg(), json_last_error());
-                }
-            } catch (\Throwable $e) {
-                // if decoding fails, then lint using JsonParser
-                $parser = new JsonParser();
-                if (!is_null($parserException = $parser->lint($json))) {
-                    throw $parserException;
-                }
-                // if JsonParser can decode successfully, but json_decode() cannot, complain loudly
-                throw new \Exception('Unknown JSON decoding error'); // @codeCoverageIgnore
-            }
-        }, JsonBrowser::ERR_DECODING_ERROR, 'Unable to decode JSON data: %s');
     }
 
     /**

--- a/tests/AttachTest.php
+++ b/tests/AttachTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace JsonBrowser\Tests;
+
+use JsonBrowser\JsonBrowser;
+use JsonBrowser\Exception;
+
+/*
+ * Test attachment to pre-existing document
+ *
+ * @package baacode/json-browser
+ * @copyright (c) 2017-2018-2018 Erayd LTD
+ * @author Steve Gilberd <steve@erayd.net>
+ * @license ISC
+ */
+class AttachTest extends \PHPUnit\Framework\TestCase
+{
+    public function testAttach()
+    {
+        $document = json_decode('{"childOne": "valueOne"}');
+        $browser = new JsonBrowser();
+        $browser->attach($document);
+        $browser->getChild('childOne')->setValue('valueTwo');
+        $this->assertEquals('valueTwo', $document->childOne);
+    }
+}

--- a/tests/ChildTest.php
+++ b/tests/ChildTest.php
@@ -17,30 +17,35 @@ class ChildTest extends \PHPUnit\Framework\TestCase
 {
     public function testChildExists()
     {
-        $browser = new JsonBrowser('{"childOne": "valueOne", "2": "valueTwo"}');
+        $browser = new JsonBrowser();
+        $browser->loadJSON('{"childOne": "valueOne", "2": "valueTwo"}');
         $this->assertTrue($browser->childExists('childOne'));
         $this->assertTrue($browser->childExists('2'));
         $this->assertTrue($browser->childExists(2)); // array_key_exists() allows sloppy typing
         $this->assertFalse($browser->childExists('childThree'));
         $this->assertFalse($browser->childExists(3));
 
-        $browser = new JsonBrowser('["valueOne", "valueTwo"]');
+        $browser = new JsonBrowser();
+        $browser->loadJSON('["valueOne", "valueTwo"]');
         $this->assertTrue($browser->childExists(0));
         $this->assertTrue($browser->childExists('1'));
         $this->assertFalse($browser->childExists(2));
         $this->assertFalse($browser->childExists("childThree"));
 
-        $browser = new JsonBrowser('"stringValue"');
+        $browser = new JsonBrowser();
+        $browser->loadJSON('"stringValue"');
         $this->assertFalse($browser->childExists('childOne'));
     }
 
     public function testGetChild()
     {
-        $array = new JsonBrowser('["valueOne"]');
+        $array = new JsonBrowser();
+        $array->loadJSON('["valueOne"]');
         $this->assertEquals('valueOne', $array->getChild(0)->getValue());
         $this->assertNull($array->getChild(1)->getValue());
 
-        $root = new JsonBrowser('{"childOne": "valueOne", "childTwo": {"childThree": "valueThree"}}');
+        $root = new JsonBrowser();
+        $root->loadJSON('{"childOne": "valueOne", "childTwo": {"childThree": "valueThree"}}');
         $childOne = $root->getChild('childOne');
         $childTwo = $root->getChild('childTwo');
         $childThree = $childTwo->getChild('childThree');
@@ -56,7 +61,8 @@ class ChildTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($childFour->getValue());
         $this->assertNull($childFive->getValue());
 
-        $root = new JsonBrowser('{"childOne": "valueOne"}', JsonBrowser::OPT_NONEXISTENT_EXCEPTIONS);
+        $root = new JsonBrowser(JsonBrowser::OPT_NONEXISTENT_EXCEPTIONS);
+        $root->loadJSON('{"childOne": "valueOne"}');
         $this->assertEquals('valueOne', $root->getChild('childOne')->getValue());
         $this->expectException(Exception::class);
         $root->getChild('childTwo');
@@ -64,7 +70,8 @@ class ChildTest extends \PHPUnit\Framework\TestCase
 
     public function testGetRoot()
     {
-        $root = new JsonBrowser('{"childOne": {"childTwo": "valueTwo"}}');
+        $root = new JsonBrowser();
+        $root->loadJSON('{"childOne": {"childTwo": "valueTwo"}}');
         $childOne = $root->getChild('childOne');
         $childTwo = $childOne->getChild('childTwo');
 
@@ -75,7 +82,8 @@ class ChildTest extends \PHPUnit\Framework\TestCase
 
     public function testGetParent()
     {
-        $root = new JsonBrowser('{"childOne": {"childTwo": "valueTwo"}}');
+        $root = new JsonBrowser();
+        $root->loadJSON('{"childOne": {"childTwo": "valueTwo"}}');
         $childOne = $root->getChild('childOne');
         $childTwo = $childOne->getChild('childTwo');
 
@@ -86,7 +94,8 @@ class ChildTest extends \PHPUnit\Framework\TestCase
 
     public function testGetSet()
     {
-        $root = new JsonBrowser('{"childOne": "valueOne"}');
+        $root = new JsonBrowser();
+        $root->loadJSON('{"childOne": "valueOne"}');
         $this->assertEquals('valueOne', $root->childOne->getValue());
 
         $root->childTwo = 'valueTwo';
@@ -95,7 +104,8 @@ class ChildTest extends \PHPUnit\Framework\TestCase
 
     public function testDynamicGetValue()
     {
-        $root = new JsonBrowser('{"childOne": "valueOne"}', JsonBrowser::OPT_GET_VALUE);
+        $root = new JsonBrowser(JsonBrowser::OPT_GET_VALUE);
+        $root->loadJSON('{"childOne": "valueOne"}');
         $this->assertEquals('valueOne', $root->childOne);
     }
 }

--- a/tests/CreateTest.php
+++ b/tests/CreateTest.php
@@ -41,7 +41,8 @@ class CreateTest extends \PHPUnit\Framework\TestCase
             $this->expectException(Exception::class);
         }
 
-        $browser = new JsonBrowser($json);
+        $browser = new JsonBrowser();
+        $browser->loadJSON($json);
         $this->assertInstanceOf(JsonBrowser::class, $browser);
 
         if ($expectSuccess) {
@@ -51,7 +52,8 @@ class CreateTest extends \PHPUnit\Framework\TestCase
 
     public function testExists()
     {
-        $browser = new JsonBrowser('{"propertyOne": {"propertyTwo": "valueTwo"}}');
+        $browser = new JsonBrowser();
+        $browser->loadJSON('{"propertyOne": {"propertyTwo": "valueTwo"}}');
 
         $this->assertTrue($browser->nodeExists());
         $this->assertTrue($browser->getNodeAt('#/propertyOne')->nodeExists());

--- a/tests/EqualityTest.php
+++ b/tests/EqualityTest.php
@@ -34,7 +34,8 @@ class EqualityTest extends \PHPUnit\Framework\TestCase
     /** @dataProvider dataIsEqual */
     public function testIsEqual(string $json, $compareTo, bool $isEqual)
     {
-        $browser = new JsonBrowser($json);
+        $browser = new JsonBrowser();
+        $browser->loadJSON($json);
         $this->assertTrue($browser->isEqualTo($browser));
         $this->assertEquals($isEqual, $browser->isEqualTo($compareTo));
     }

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -48,10 +48,9 @@ class ExceptionTest extends \PHPUnit\Framework\TestCase
 
     public function getExceptionBrowser()
     {
-        return new JsonBrowser(
-            '{"childOne": "valueOne", "childTwo": ["valueTwo"]}',
-            JsonBrowser::OPT_NONEXISTENT_EXCEPTIONS
-        );
+        $browser = new JsonBrowser(JsonBrowser::OPT_NONEXISTENT_EXCEPTIONS);
+        $browser->loadJSON('{"childOne": "valueOne", "childTwo": ["valueTwo"]}');
+        return $browser;
     }
 
     public function testNoExceptionOnValidNode()
@@ -103,7 +102,7 @@ class ExceptionTest extends \PHPUnit\Framework\TestCase
 
     public function testNonExistentChildValueException()
     {
-        $browser = new JsonBrowser('{}', JsonBrowser::OPT_NONEXISTENT_EXCEPTIONS | JsonBrowser::OPT_GET_VALUE);
+        $browser = new JsonBrowser(JsonBrowser::OPT_NONEXISTENT_EXCEPTIONS | JsonBrowser::OPT_GET_VALUE);
         $this->expectException(Exception::class);
         $browser->childThree;
     }

--- a/tests/IteratorTest.php
+++ b/tests/IteratorTest.php
@@ -17,7 +17,8 @@ class IteratorTest extends \PHPUnit\Framework\TestCase
 {
     public function testEmpty()
     {
-        $browser = new JsonBrowser('"notAContainer"');
+        $browser = new JsonBrowser();
+        $browser->loadJSON('"notAContainer"');
 
         foreach ($browser as $child) {
             $this->assertTrue(false); // should never execute
@@ -27,7 +28,8 @@ class IteratorTest extends \PHPUnit\Framework\TestCase
 
     public function testArray()
     {
-        $browser = new JsonBrowser('["valueOne", "valueTwo"]');
+        $browser = new JsonBrowser();
+        $browser->loadJSON('["valueOne", "valueTwo"]');
         $count = 0;
         foreach ($browser as $key => $child) {
             $this->assertEquals($count++, $key);
@@ -43,7 +45,8 @@ class IteratorTest extends \PHPUnit\Framework\TestCase
 
     public function testObject()
     {
-        $browser = new JsonBrowser('{"childOne": "valueOne", "childTwo": {"childThree": "valueThree"}}');
+        $browser = new JsonBrowser();
+        $browser->loadJSON('{"childOne": "valueOne", "childTwo": {"childThree": "valueThree"}}');
 
         $count = 0;
         foreach ($browser as $key => $child) {

--- a/tests/JSONTest.php
+++ b/tests/JSONTest.php
@@ -17,7 +17,8 @@ class JSONTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetJSON()
     {
-        $browser = new JsonBrowser('{"childOne": {"childTwo": ["valueThree", "valueFour"]}}');
+        $browser = new JsonBrowser();
+        $browser->loadJSON('{"childOne": {"childTwo": ["valueThree", "valueFour"]}}');
         $childTwo = $browser->getNodeAt('#/childOne/childTwo');
         $this->assertEquals("[\n    \"valueThree\",\n    \"valueFour\"\n]", $childTwo->getJSON());
     }

--- a/tests/PathTest.php
+++ b/tests/PathTest.php
@@ -17,7 +17,8 @@ class PathTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetPath()
     {
-        $root = new JsonBrowser('{"child~/One": {"child%Two": ["valueThree", "valueFour"]}}');
+        $root = new JsonBrowser();
+        $root->loadJSON('{"child~/One": {"child%Two": ["valueThree", "valueFour"]}}');
         $childFour = $root->getChild('child~/One')->getChild('child%Two')->getChild(1);
         $childFive = $root->getChild('child~/One')->getChild(5);
 
@@ -34,7 +35,7 @@ class PathTest extends \PHPUnit\Framework\TestCase
 
     public function testNodeByPathException()
     {
-        $root = new JsonBrowser('{}', JsonBrowser::OPT_NONEXISTENT_EXCEPTIONS);
+        $root = new JsonBrowser(JsonBrowser::OPT_NONEXISTENT_EXCEPTIONS);
 
         $this->expectException(Exception::class);
         $root->getNodeAt('#/this/path/does/not/exist');
@@ -42,7 +43,7 @@ class PathTest extends \PHPUnit\Framework\TestCase
 
     public function testValueByPathException()
     {
-        $root = new JsonBrowser('{}', JsonBrowser::OPT_NONEXISTENT_EXCEPTIONS);
+        $root = new JsonBrowser(JsonBrowser::OPT_NONEXISTENT_EXCEPTIONS);
 
         $this->expectException(Exception::class);
         $root->getValueAt('#/this/path/does/not/exist');

--- a/tests/RootTest.php
+++ b/tests/RootTest.php
@@ -17,7 +17,8 @@ class RootTest extends \PHPUnit\Framework\TestCase
 {
     public function testChangeRoot()
     {
-        $root = new JsonBrowser('{"childOne": {"childTwo": "valueTwo"}}');
+        $root = new JsonBrowser();
+        $root->loadJSON('{"childOne": {"childTwo": "valueTwo"}}');
         $childOne = $root->getChild('childOne')->asRoot();
 
         $this->assertEquals('{"childTwo":"valueTwo"}', $childOne->getJSON(0));

--- a/tests/SetTest.php
+++ b/tests/SetTest.php
@@ -17,7 +17,8 @@ class SetTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetRoot()
     {
-        $root = new JsonBrowser('{"childOne": {"childTwo": ["valueThree", "valueFour"]}}');
+        $root = new JsonBrowser();
+        $root->loadJSON('{"childOne": {"childTwo": ["valueThree", "valueFour"]}}');
 
         $root->setValue(5);
 
@@ -27,7 +28,8 @@ class SetTest extends \PHPUnit\Framework\TestCase
 
     public function testSetChild()
     {
-        $root = new JsonBrowser('{"childOne": "valueOne", "childTwo": ["valueThree", "valueFour"]}');
+        $root = new JsonBrowser();
+        $root->loadJSON('{"childOne": "valueOne", "childTwo": ["valueThree", "valueFour"]}');
         $childOne = $root->getChild('childOne');
         $childFour = $root->getChild('childTwo')->getChild(1);
         $childFive = $root->getChild('childTwo')->getChild(2);
@@ -50,7 +52,8 @@ class SetTest extends \PHPUnit\Framework\TestCase
 
     public function testPromote()
     {
-        $root = new JsonBrowser('{"childOne": null, "childTwo": []}');
+        $root = new JsonBrowser();
+        $root->loadJSON('{"childOne": null, "childTwo": []}');
         $gcOne = $root->getChild('childOne')->getChild('gcOne');
         $gcTwo = $root->getChild('childTwo')->getChild('gcTwo');
         $gcThree = $root->getChild('childThree')->getChild(3);
@@ -75,7 +78,8 @@ class SetTest extends \PHPUnit\Framework\TestCase
 
     public function testInvalidContainer()
     {
-        $root = new JsonBrowser('{"childOne": "valueOne"}');
+        $root = new JsonBrowser();
+        $root->loadJSON('{"childOne": "valueOne"}');
 
         $this->expectException(Exception::class);
         $root->getNodeAt('#/childOne/childTwo/childThree')->setValue(5);
@@ -83,17 +87,15 @@ class SetTest extends \PHPUnit\Framework\TestCase
 
     public function testDeleteRoot()
     {
-        $root = new JsonBrowser('{}');
+        $root = new JsonBrowser();
         $root->deleteValue();
         $this->assertEquals('null', $root->getJSON(0));
     }
 
     public function testDeleteChild()
     {
-        $root = new JsonBrowser(
-            '{"childOne": ["valueOne"], "childTwo": {"childThree": "valueThree"}}',
-            JsonBrowser::OPT_NONEXISTENT_EXCEPTIONS
-        );
+        $root = new JsonBrowser(JsonBrowser::OPT_NONEXISTENT_EXCEPTIONS);
+        $root->loadJSON('{"childOne": ["valueOne"], "childTwo": {"childThree": "valueThree"}}');
         $childOne = $root->getChild('childOne');
         $gcOne = $childOne->getChild(0);
         $childTwo = $root->getChild('childOne');
@@ -117,7 +119,8 @@ class SetTest extends \PHPUnit\Framework\TestCase
 
     public function testDeleteEmptyContainers()
     {
-        $root = new JsonBrowser('[[[[["valueOne", "valueTwo"]], "valueThree"]]]');
+        $root = new JsonBrowser();
+        $root->loadJSON('[[[[["valueOne", "valueTwo"]], "valueThree"]]]');
 
         $root->deleteValueAt('#/0/0/0/0/1', true);
         $this->assertEquals('[[[[["valueOne"]],"valueThree"]]]', $root->getJSON(0));
@@ -134,7 +137,8 @@ class SetTest extends \PHPUnit\Framework\TestCase
 
     public function testDeleteChildOfInvalidContainer()
     {
-        $browser = new JsonBrowser('"this is a string"');
+        $browser = new JsonBrowser();
+        $browser->loadJSON('"this is a string"');
         $browser->deleteValueAt('#/non/existent/path');
         $this->assertEquals('"this is a string"', $browser->getJSON());
     }

--- a/tests/SiblingTest.php
+++ b/tests/SiblingTest.php
@@ -17,13 +17,14 @@ class SiblingTest extends \PHPUnit\Framework\TestCase
 {
     public function testRootSiblingExists()
     {
-        $root = new JsonBrowser('{}');
+        $root = new JsonBrowser();
         $this->assertFalse($root->siblingExists('siblingOne'));
     }
 
     public function testSiblingExists()
     {
-        $root = new JsonBrowser('{"childOne": "valueOne", "childTwo": "valueTwo"}');
+        $root = new JsonBrowser();
+        $root->loadJSON('{"childOne": "valueOne", "childTwo": "valueTwo"}');
         $childOne = $root->getChild('childOne');
         $childTwo = $root->getChild('childTwo');
         $childThree = $root->getChild('childThree');
@@ -36,7 +37,8 @@ class SiblingTest extends \PHPUnit\Framework\TestCase
 
     public function testGetSibling()
     {
-        $root = new JsonBrowser('{"childOne": "valueOne", "childTwo": "valueTwo"}');
+        $root = new JsonBrowser();
+        $root->loadJSON('{"childOne": "valueOne", "childTwo": "valueTwo"}');
         $childOne = $root->getChild('childOne');
         $childThree = $childOne->getSibling('childThree');
         $childTwo = $childThree->getSibling('childTwo');
@@ -45,7 +47,8 @@ class SiblingTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('valueTwo', $childTwo->getValue());
         $this->assertNull($childThree->getValue());
 
-        $root = new JsonBrowser('{"childOne": "valueOne"}', JsonBrowser::OPT_NONEXISTENT_EXCEPTIONS);
+        $root = new JsonBrowser(JsonBrowser::OPT_NONEXISTENT_EXCEPTIONS);
+        $root->loadJSON('{"childOne": "valueOne"}');
         $childOne = $root->getChild('childOne');
         $this->expectException(Exception::class);
         $childTwo = $childOne->getSibling('childTwo');

--- a/tests/TypeTest.php
+++ b/tests/TypeTest.php
@@ -33,7 +33,8 @@ class TypeTest extends \PHPUnit\Framework\TestCase
     /** @dataProvider dataType */
     public function testType(string $json, int $type)
     {
-        $browser = new JsonBrowser($json);
+        $browser = new JsonBrowser();
+        $browser->loadJSON($json);
         $this->assertEquals($type, $browser->getType());
     }
 
@@ -62,13 +63,15 @@ class TypeTest extends \PHPUnit\Framework\TestCase
     /** @dataProvider dataIsType */
     public function testIsType(string $json, int $type, bool $all, bool $isMatch)
     {
-        $browser = new JsonBrowser($json);
+        $browser = new JsonBrowser();
+        $browser->loadJSON($json);
         $this->assertEquals($isMatch, $browser->isType($type, $all));
     }
 
     public function testIsNotType()
     {
-        $browser = new JsonBrowser('1.000000001');
+        $browser = new JsonBrowser();
+        $browser->loadJSON('1.000000001');
         $this->assertTrue($browser->isNotType(JsonBrowser::TYPE_INTEGER));
     }
 }


### PR DESCRIPTION
## What
 * Move JSON loading from constructor to JsonBrowser::loadJSON()
 * Add JsonBrowser::attach()

## Why
Because manipulating existing documents is often desirable, particularly when setting values.

Note that this change breaks the constructor API, and will require a major release.