### PR TITLE
Allow passing the document to the constructor

### DIFF
--- a/src/JsonBrowser.php
+++ b/src/JsonBrowser.php
@@ -22,6 +22,9 @@ class JsonBrowser implements \IteratorAggregate
     /** Get node value instead of JsonBrowser object for __get() */
     const OPT_GET_VALUE = 2;
 
+    /** Treat the document definition passed to the constructor as JSON, and decode it */
+    const OPT_DECODE = 4;
+
     /** Default config options [none] */
     const OPT_DEFAULT = 0;
 
@@ -82,12 +85,16 @@ class JsonBrowser implements \IteratorAggregate
      * @since 1.0.0
      *
      * @param int $options Configuration options (bitmask)
+     * @param mixed $document Reference to the default document
      */
-    public function __construct(int $options = self::OPT_DEFAULT)
+    public function __construct(int $options = self::OPT_DEFAULT, &$document = null)
     {
-        $defaultDocument = null;
         $this->options = $options;
-        $this->context = new Context($defaultDocument, $options);
+        if ($this->options & self::OPT_DECODE) {
+            $this->loadJSON($document);
+        } else {
+            $this->attach($document);
+        }
     }
 
     /**

--- a/tests/AttachTest.php
+++ b/tests/AttachTest.php
@@ -18,8 +18,7 @@ class AttachTest extends \PHPUnit\Framework\TestCase
     public function testAttach()
     {
         $document = json_decode('{"childOne": "valueOne"}');
-        $browser = new JsonBrowser();
-        $browser->attach($document);
+        $browser = new JsonBrowser(JsonBrowser::OPT_DEFAULT, $document);
         $browser->getChild('childOne')->setValue('valueTwo');
         $this->assertEquals('valueTwo', $document->childOne);
     }

--- a/tests/CreateTest.php
+++ b/tests/CreateTest.php
@@ -41,8 +41,7 @@ class CreateTest extends \PHPUnit\Framework\TestCase
             $this->expectException(Exception::class);
         }
 
-        $browser = new JsonBrowser();
-        $browser->loadJSON($json);
+        $browser = new JsonBrowser(JsonBrowser::OPT_DECODE, $json);
         $this->assertInstanceOf(JsonBrowser::class, $browser);
 
         if ($expectSuccess) {


### PR DESCRIPTION
## What
Allow passing the document to the constructor (second argument), either as a string to decode, or a document reference to attach.

## Why
Convenience.