### PR TITLE
Add ability to annotate nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,19 @@ $json = $node->getJSON();
 // get a node as the root of a subtree
 $root = $node->asRoot();
 
+// set named annotation on a node
+$node->setAnnotation('myAnnotation', 'myValue'); // append to existing values
+$node->setAnnotation('myOtherAnnotation', 'myOtherValue', true); // overwrite previous values
+
+// get latest value for a named annotation, or null if not set
+$annotation = $node->getAnnotation('myAnnotation');
+
+// get array of values for a named annotation, empty array if not set
+$annotations = $node->getAnnotations('myAnnotation');
+
+// get an associative array of all annotations on a node, empty array if none set
+$annotations = $node->getAnnotations();
+
 ```
 
 Configuration Options

--- a/src/Context.php
+++ b/src/Context.php
@@ -21,6 +21,9 @@ class Context
     /** Decoded JSON document */
     private $document = null;
 
+    /** Annotation document */
+    private $annotations = [];
+
     /** Path to root location in document */
     private $path = [];
 
@@ -48,6 +51,7 @@ class Context
     {
         $subtree = clone $this;
         $subtree->path = array_merge($this->path, $path);
+        $subtree->annotations = &$this->annotations;
         
         return $subtree;
     }
@@ -190,6 +194,51 @@ class Context
             // we're at the root, so set the target to null rather than unsetting it
             $target = null;
         }
+    }
+
+    /**
+     * Get annotations for a given path
+     *
+     * @since 2.1.0
+     *
+     * @param array  $path Array of path elements
+     * @param string $name Annotation name
+     * @return array Array of annotation values
+     */
+    public function getAnnotations(array $path, string $name = null) : array
+    {
+        $path = Util::encodePointer(array_merge($this->path, $path));
+        if (!array_key_exists($path, $this->annotations)) {
+            return [];
+        }
+
+        if (!is_null($name)) {
+            return $this->annotations[$path][$name] ?? [];
+        } else {
+            return $this->annotations[$path];
+        }
+    }
+
+    /**
+     * Set an annotation for a given path
+     *
+     * @since 2.1.0
+     *
+     * @param array  $path  Array of path elements
+     * @param string $name  Annotation name
+     * @param mixed  $value Annotation value
+     * @param bool   $clear Clear existing annotations with the same name
+     */
+    public function setAnnotation(array $path, string $name, $value, bool $clear = false)
+    {
+        $path = Util::encodePointer(array_merge($this->path, $path));
+        if (!array_key_exists($path, $this->annotations)) {
+            $this->annotations[$path] = [];
+        }
+        if ($clear || !array_key_exists($name, $this->annotations[$path])) {
+            $this->annotations[$path][$name] = [];
+        }
+        $this->annotations[$path][$name][] = $value;
     }
 
     /**

--- a/src/JsonBrowser.php
+++ b/src/JsonBrowser.php
@@ -195,6 +195,33 @@ class JsonBrowser implements \IteratorAggregate
     }
 
     /**
+     * Get single node annotation
+     *
+     * @since 2.1.0
+     *
+     * @param string $name Annotation name
+     * @return mixed Most recently-set annotation matching the given name, or null if not set
+     */
+    public function getAnnotation(string $name)
+    {
+        $annotations = $this->getAnnotations($name);
+        return count($annotations) ? end($annotations) : null;
+    }
+
+    /**
+     * Get node annotations
+     *
+     * @since 2.1.0
+     *
+     * @param string $name Annotation name
+     * @return array Array of annotations matching $name, or an associative array of all annotations
+     */
+    public function getAnnotations(string $name = null) : array
+    {
+        return $this->context->getAnnotations($this->path, $name);
+    }
+
+    /**
      * Get a child node
      *
      * @since 1.0.0
@@ -513,6 +540,18 @@ class JsonBrowser implements \IteratorAggregate
     public function nodeExists() : bool
     {
         return $this->context->valueExists($this->path);
+    }
+
+    /**
+     * Set a node annotation
+     *
+     * @param string $name  Annotation name
+     * @param mixed  $value Annotation value
+     * @param bool   $clear Clear existing annotations with the same name
+     */
+    public function setAnnotation(string $name, $value, bool $clear = false)
+    {
+        $this->context->setAnnotation($this->path, $name, $value, $clear);
     }
 
     /**

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace JsonBrowser\Tests;
+
+use JsonBrowser\JsonBrowser;
+use JsonBrowser\Exception;
+
+/*
+ * Test node annotations
+ *
+ * @package baacode/json-browser
+ * @copyright (c) 2017-2018-2018 Erayd LTD
+ * @author Steve Gilberd <steve@erayd.net>
+ * @license ISC
+ */
+class AnnotationTest extends \PHPUnit\Framework\TestCase
+{
+    public function testAnnotations()
+    {
+        $browser = new JsonBrowser();
+        $browser->loadJSON('{"childOne": {"childTwo": "valueTwo"}}');
+        $childOne = $browser->getChild('childOne');
+        $childTwo = $childOne->getChild('childTwo');
+
+        // no annotations present, getting returns an empty array both with and without an annotation name
+        $this->assertSame([], $childOne->getAnnotations());
+        $this->assertSame([], $childOne->getAnnotations('aOne'));
+
+        $childOne->setAnnotation('aOne', 'aOneValueOne');
+        $childTwo->setAnnotation('aOne', 'aOneValueTwo');
+        $childTwo->setAnnotation('aTwo', 'aTwoValueOne');
+        $childTwo->setAnnotation('aTwo', 'aTwoValueTwo');
+
+        // annotations are applied to the correct node and append without overwriting by default
+        $this->assertSame(['aOne' => ['aOneValueOne']], $childOne->getAnnotations());
+        $this->assertSame(
+            ['aOne' => ['aOneValueTwo'], 'aTwo' => ['aTwoValueOne', 'aTwoValueTwo']],
+            $childTwo->getAnnotations()
+        );
+        $this->assertSame(['aTwoValueOne', 'aTwoValueTwo'], $childTwo->getAnnotations('aTwo'));
+
+        // fetching a single annotation returns the latest-set, or null if not set
+        $this->assertSame('aTwoValueTwo', $childTwo->getAnnotation('aTwo'));
+        $this->assertNull($childTwo->getAnnotation('aThree'));
+
+        // existing annotations are cleared prior to setting the new value
+        $childTwo->setAnnotation('aTwo', 'aTwoValueThree', true);
+        $this->assertSame(['aTwoValueThree'], $childTwo->getAnnotations('aTwo'));
+
+        // annotations still work with a subtree root
+        $childTwoRoot = $childTwo->asRoot();
+        $childTwoRoot->setAnnotation('aThree', 'aThreeValueOne');
+        $this->assertSame(
+            ['aOne' => ['aOneValueTwo'], 'aTwo' => ['aTwoValueThree'], 'aThree' => ['aThreeValueOne']],
+            $childTwoRoot->getAnnotations()
+        );
+        $this->assertSame($childTwo->getAnnotations(), $childTwoRoot->getAnnotations());
+    }
+}


### PR DESCRIPTION
## What
Add the ability to annotate nodes
 * `JsonBrowser::getAnnotation()`
 * `JsonBrowser::getAnnotations()`
 * `JsonBrowser::setAnnotation()`

## Why
Because a full JSON-schema implementation requires this behavior, and it makes more sense to integrate the capability into this library rather than try to bolt it on externally.