### PR TITLE
Add subclass identity tests

### DIFF
--- a/tests/SubclassTest.php
+++ b/tests/SubclassTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace JsonBrowser\Tests;
+
+/*
+ * Test subclass identity when initial instantiation is a subclass
+ *
+ * @package baacode/json-browser
+ * @copyright (c) 2017-2018-2018 Erayd LTD
+ * @author Steve Gilberd <steve@erayd.net>
+ * @license ISC
+ */
+class SubclassTest extends \PHPUnit\Framework\TestCase
+{
+    private function getBrowser() : TestBrowser
+    {
+        $json = '{"childOne": {"childTwo": "valueTwo"}}';
+        return new TestBrowser(TestBrowser::OPT_DECODE, $json);
+    }
+
+    public function testCreate()
+    {
+        $this->assertInstanceOf(TestBrowser::class, $this->getBrowser());
+    }
+
+    public function testChild()
+    {
+        $this->assertInstanceOf(TestBrowser::class, $this->getBrowser()->getChild('childOne'));
+    }
+
+    public function testPath()
+    {
+        $this->assertInstanceOf(TestBrowser::class, $this->getBrowser()->getNodeAt('#/childOne/childTwo'));
+    }
+
+    public function testUnset()
+    {
+        $this->assertInstanceOf(TestBrowser::class, $this->getBrowser()->getChild('childThree'));
+    }
+
+    public function testAsRoot()
+    {
+        $root = $this->getBrowser()->getNodeAt('#/childOne/childTwo')->asRoot();
+        $this->assertInstanceOf(TestBrowser::class, $root);
+    }
+}

--- a/tests/TestBrowser.php
+++ b/tests/TestBrowser.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace JsonBrowser\Tests;
+
+use JsonBrowser\JsonBrowser;
+
+/*
+ * Test subclass of JsonBrowser
+ *
+ * @package baacode/json-browser
+ * @copyright (c) 2017-2018-2018 Erayd LTD
+ * @author Steve Gilberd <steve@erayd.net>
+ * @license ISC
+ */
+class TestBrowser extends JsonBrowser
+{
+}


### PR DESCRIPTION
## What
Add tests to verify that if `JsonBrowser` is instantiated as a subclass, all nodes created during operation are also of that subclass.

## Why
Because new nodes are created via cloning (which preserves class identity). Adding these tests prevents somebody accidentally sneaking a `new JsonBrowser` into the codebase later.