### PR TITLE
Allow getting a type mask with only the most-specific bit set

### DIFF
--- a/src/JsonBrowser.php
+++ b/src/JsonBrowser.php
@@ -369,9 +369,10 @@ class JsonBrowser implements \IteratorAggregate
      *
      * @since 1.0.0
      *
+     * @param bool $onlyOne Get only the most specific type, rather than all applicable
      * @return int Bitmask list of applicable types (See JsonBrowser::TYPE_* constants)
      */
-    public function getType() : int
+    public function getType(bool $onlyOne = false) : int
     {
         $documentValue = $this->getValue();
 
@@ -390,7 +391,11 @@ class JsonBrowser implements \IteratorAggregate
         if (is_numeric($documentValue)) {
             $type = self::TYPE_NUMBER;
             if (is_int($documentValue) || $documentValue == floor($documentValue)) {
-                $type |= self::TYPE_INTEGER;
+                if ($onlyOne) {
+                    $type = self::TYPE_INTEGER;
+                } else {
+                    $type |= self::TYPE_INTEGER;
+                }
             }
             return $type;
         }

--- a/tests/TypeTest.php
+++ b/tests/TypeTest.php
@@ -74,4 +74,12 @@ class TypeTest extends \PHPUnit\Framework\TestCase
         $browser->loadJSON('1.000000001');
         $this->assertTrue($browser->isNotType(JsonBrowser::TYPE_INTEGER));
     }
+
+    public function testOnlyOne()
+    {
+        $browser = new JsonBrowser();
+        $browser->loadJSON('1');
+        $this->assertSame(JsonBrowser::TYPE_INTEGER, $browser->getType(true));
+        $this->assertSame(JsonBrowser::TYPE_INTEGER|JsonBrowser::TYPE_NUMBER, $browser->getType(false));
+    }
 }


### PR DESCRIPTION
## What
Allow getting a type mask with only the most-specific bit set

## Why
Because sometimes direct comparisons with `JsonBrowser::TYPE_INTEGER` are necessary, and must exclude `JsonBrowser::TYPE_NUMBER`.