### PR TITLE
Add JsonBrowser::isRoot()

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ $browser->deleteValueAt('#/childName/grandchildName/4')
 // get root node
 $root = $node->getRoot();
 
+// test whether a node is the root
+$nodeIsRoot = $node->isRoot();
+
 // get parent node
 $parent = $node->getParent();
 

--- a/src/JsonBrowser.php
+++ b/src/JsonBrowser.php
@@ -275,7 +275,7 @@ class JsonBrowser implements \IteratorAggregate
      */
     public function getKey()
     {
-        return count($this->path) ? end($this->path) : null;
+        return $this->isRoot() ? null : end($this->path);
     }
 
     /**
@@ -308,7 +308,7 @@ class JsonBrowser implements \IteratorAggregate
     public function getParent()
     {
         // the root node has no parent, so return null
-        if (!count($this->path)) {
+        if ($this->isRoot()) {
             return null;
         }
         
@@ -486,6 +486,18 @@ class JsonBrowser implements \IteratorAggregate
     }
 
     /**
+     * Test whether the current node is the document root
+     *
+     * @since 2.3.0
+     *
+     * @return bool Whether this node is the document root
+     */
+    public function isRoot() : bool
+    {
+        return !count($this->path);
+    }
+
+    /**
      * Test whether the document value is of a given type
      *
      * @since 1.3.0
@@ -599,7 +611,7 @@ class JsonBrowser implements \IteratorAggregate
     public function siblingExists($key) : bool
     {
         // root nodes have no siblings
-        if (!count($this->path)) {
+        if ($this->isRoot()) {
             return false;
         }
 


### PR DESCRIPTION
## What
Add `JsonBrowser::isRoot()` to test whether a node is the document root.

## Why
Because sometimes this is useful to know directly, and not just in the context of other methods.