### PR TITLE
Get values clamped or cast to a specific type mask

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,4 +141,5 @@ Requirements
 
  - PHP >= 7.0
  - PHP's native JSON extension
+ - PHP's native mbstring extension
  - seld/jsonlint >= 1.0

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
     "require": {
         "php": "^7.0",
         "ext-json": "*",
+        "ext-mbstring": "*",
         "seld/jsonlint": "^1.0"
     },
     "require-dev": {

--- a/src/Context.php
+++ b/src/Context.php
@@ -75,8 +75,8 @@ class Context
      *
      * @since 1.5.0
      *
-     * @param array $path Array of path elements
-     * @param bool Reference - set to true if the value exists, false otherwise
+     * @param array $path   Array of path elements
+     * @param bool  $exists Reference - set to true if the value exists, false otherwise
      * @return mixed|null Value data, or null if value does not exist
      */
     public function getValue(array $path, bool &$exists = null)
@@ -106,7 +106,7 @@ class Context
      *
      * @since 1.5.0
      *
-     * @param array $path Array of path elements
+     * @param array $path  Array of path elements
      * @param mixed $value Value data to set
      * @param bool  $padSparseArray Whether to left-pad sparse arrays with null values
      */

--- a/src/Context.php
+++ b/src/Context.php
@@ -9,7 +9,7 @@ namespace JsonBrowser;
  * @since 1.5.0
  *
  * @package baacode/json-browser
- * @copyright (c) 2017-2018-2018 Erayd LTD
+ * @copyright (c) 2017-2018 Erayd LTD
  * @author Steve Gilberd <steve@erayd.net>
  * @license ISC
  */

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -19,9 +19,9 @@ class Exception extends \Exception
      *
      * @since 1.0.0
      *
-     * @param int $code Error code
+     * @param int    $code    Error code
      * @param string $message Error message
-     * @param array $params Error params
+     * @param array  $params  Error params
      */
     public function __construct(int $code, string $message, ...$params)
     {
@@ -46,10 +46,10 @@ class Exception extends \Exception
      *
      * @since 1.0.0
      *
-     * @param callable $target Function to wrap and execute
-     * @param int $code Error code
-     * @param string $message Error message
-     * @param array $params Error params
+     * @param callable $target  Function to wrap and execute
+     * @param int      $code    Error code
+     * @param string   $message Error message
+     * @param array    $params  Error params
      */
     public static function wrap(callable $target, int $code, string $message, ...$params)
     {

--- a/src/JsonBrowser.php
+++ b/src/JsonBrowser.php
@@ -90,7 +90,7 @@ class JsonBrowser implements \IteratorAggregate
      *
      * @since 1.0.0
      *
-     * @param int $options Configuration options (bitmask)
+     * @param int  $options   Configuration options (bitmask)
      * @param mixed $document Reference to the default document
      */
     public function __construct(int $options = self::OPT_DEFAULT, &$document = null)
@@ -126,7 +126,7 @@ class JsonBrowser implements \IteratorAggregate
      *
      * @since 1.5.0
      *
-     * @param mixed $key Index key
+     * @param mixed $key   Index key
      * @param mixed $value Value data to set
      */
     public function __set($key, $value)
@@ -192,8 +192,8 @@ class JsonBrowser implements \IteratorAggregate
      *
      * @since 1.5.0
      *
-     * @param string $path JSON pointer to the node that should be deleted
-     * @param bool $deleteEmpty Whether to delete empty containers
+     * @param string $path        JSON pointer to the node that should be deleted
+     * @param bool   $deleteEmpty Whether to delete empty containers
      */
     public function deleteValueAt(string $path, bool $deleteEmpty = false)
     {
@@ -497,7 +497,7 @@ class JsonBrowser implements \IteratorAggregate
      * @since 1.3.0
      *
      * @param int $types Types to test for
-     * @param int $all Whether to require all types, or just one
+     * @param int $all   Whether to require all types, or just one
      * @return bool Whether the type matches
      */
     public function isType(int $types, bool $all = false) : bool

--- a/src/JsonBrowser.php
+++ b/src/JsonBrowser.php
@@ -374,41 +374,7 @@ class JsonBrowser implements \IteratorAggregate
      */
     public function getType(bool $onlyOne = false) : int
     {
-        $documentValue = $this->getValue();
-
-        if (is_null($documentValue)) {
-            return self::TYPE_NULL;
-        }
-
-        if (is_bool($documentValue)) {
-            return self::TYPE_BOOLEAN;
-        }
-
-        if (is_string($documentValue)) {
-            return self::TYPE_STRING;
-        }
-
-        if (is_numeric($documentValue)) {
-            $type = self::TYPE_NUMBER;
-            if (is_int($documentValue) || $documentValue == floor($documentValue)) {
-                if ($onlyOne) {
-                    $type = self::TYPE_INTEGER;
-                } else {
-                    $type |= self::TYPE_INTEGER;
-                }
-            }
-            return $type;
-        }
-
-        if (is_array($documentValue)) {
-            return self::TYPE_ARRAY;
-        }
-
-        if (is_object($documentValue)) {
-            return self::TYPE_OBJECT;
-        }
-
-        throw new Exception(self::ERR_UNKNOWN_TYPE, 'Unknown type: %s', gettype($documentValue)); // @codeCoverageIgnore
+        return Util::typeMask($this->getValue(), $onlyOne);
     }
 
     /**

--- a/src/Util.php
+++ b/src/Util.php
@@ -242,7 +242,8 @@ abstract class Util
         // -> to a boolean indicating whether the number is non-zero
         if ($type & JsonBrowser::TYPE_NUMBER) {
             if ($asType & JsonBrowser::TYPE_INTEGER) {
-                return $value > \PHP_INT_MAX ? floor($value) : (int) floor($value);
+                $int = $value > 0 ? floor($value) : ceil($value);
+                return abs($int) > \PHP_INT_MAX ? $int : (int) $int;
             } elseif ($asType & JsonBrowser::TYPE_STRING) {
                 return json_encode($value);
             } elseif ($asType & JsonBrowser::TYPE_ARRAY) {

--- a/src/Util.php
+++ b/src/Util.php
@@ -235,15 +235,14 @@ abstract class Util
         }
 
         // cast numbers
-        // -> to an integer (or float if larger than PHP_INT_MAX), with the fractional component discarded
+        // -> to an integer, with the fractional component discarded
         // -> to a string representation of the number, in base-10
         // -> to the only member [0] of an array
         // -> to the 'value' property of an stdClass object
         // -> to a boolean indicating whether the number is non-zero
         if ($type & JsonBrowser::TYPE_NUMBER) {
             if ($asType & JsonBrowser::TYPE_INTEGER) {
-                $int = $value > 0 ? floor($value) : ceil($value);
-                return abs($int) > \PHP_INT_MAX ? $int : (int) $int;
+                return (int) $value;
             } elseif ($asType & JsonBrowser::TYPE_STRING) {
                 return json_encode($value);
             } elseif ($asType & JsonBrowser::TYPE_ARRAY) {

--- a/src/Util.php
+++ b/src/Util.php
@@ -138,8 +138,8 @@ abstract class Util
      *
      * @since 2.4.0 (was JsonBrowser::getType() in previous versions)
      *
-     * @param mixed $value Value to test
-     * @param bool $onlyOne Whether to set only one type (the most specific)
+     * @param mixed $value   Value to test
+     * @param bool  $onlyOne Whether to set only one type (the most specific)
      * @return int Type mask
      */
     public static function typeMask($value, bool $onlyOne = false) : int
@@ -184,7 +184,7 @@ abstract class Util
      *
      * @since 2.4.0
      *
-     * @param int $asType The type mask to cast to
+     * @param int $asType  The type mask to cast to
      * @param mixed $value The value to cast
      * @return mixed The cast value
      */

--- a/src/Util.php
+++ b/src/Util.php
@@ -9,7 +9,7 @@ namespace JsonBrowser;
  * @since 1.5.0
  *
  * @package baacode/json-browser
- * @copyright (c) 2017-2018-2018 Erayd LTD
+ * @copyright (c) 2017-2018 Erayd LTD
  * @author Steve Gilberd <steve@erayd.net>
  * @license ISC
  */

--- a/src/Util.php
+++ b/src/Util.php
@@ -132,4 +132,50 @@ abstract class Util
 
         return true;
     }
+
+    /**
+     * Get the type mask for a given value
+     *
+     * @since 2.4.0 (was JsonBrowser::getType() in previous versions)
+     *
+     * @param mixed $value Value to test
+     * @param bool $onlyOne Whether to set only one type (the most specific)
+     * @return int Type mask
+     */
+    public static function typeMask($value, bool $onlyOne = false) : int
+    {
+        if (is_null($value)) {
+            return JsonBrowser::TYPE_NULL;
+        }
+
+        if (is_bool($value)) {
+            return JsonBrowser::TYPE_BOOLEAN;
+        }
+
+        if (is_string($value)) {
+            return JsonBrowser::TYPE_STRING;
+        }
+
+        if (is_numeric($value)) {
+            $type = JsonBrowser::TYPE_NUMBER;
+            if (is_int($value) || $value == floor($value)) {
+                if ($onlyOne) {
+                    $type = JsonBrowser::TYPE_INTEGER;
+                } else {
+                    $type |= JsonBrowser::TYPE_INTEGER;
+                }
+            }
+            return $type;
+        }
+
+        if (is_array($value)) {
+            return JsonBrowser::TYPE_ARRAY;
+        }
+
+        if (is_object($value)) {
+            return JsonBrowser::TYPE_OBJECT;
+        }
+
+        throw new Exception(JsonBrowser::ERR_UNKNOWN_TYPE, 'Unknown type: %s', gettype($value)); // @codeCoverageIgnore
+    }
 }

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -9,7 +9,7 @@ use JsonBrowser\Exception;
  * Test node annotations
  *
  * @package baacode/json-browser
- * @copyright (c) 2017-2018-2018 Erayd LTD
+ * @copyright (c) 2017-2018 Erayd LTD
  * @author Steve Gilberd <steve@erayd.net>
  * @license ISC
  */

--- a/tests/AttachTest.php
+++ b/tests/AttachTest.php
@@ -9,7 +9,7 @@ use JsonBrowser\Exception;
  * Test attachment to pre-existing document
  *
  * @package baacode/json-browser
- * @copyright (c) 2017-2018-2018 Erayd LTD
+ * @copyright (c) 2017-2018 Erayd LTD
  * @author Steve Gilberd <steve@erayd.net>
  * @license ISC
  */

--- a/tests/CastTest.php
+++ b/tests/CastTest.php
@@ -72,6 +72,7 @@ class CastTest extends \PHPUnit\Framework\TestCase
             [JsonBrowser::TYPE_STRING, false, '5.01', $numberJSON],
             [JsonBrowser::TYPE_NUMBER, true, 5.01, $numberJSON],
             [JsonBrowser::TYPE_INTEGER, false, 5, $numberJSON],
+            [JsonBrowser::TYPE_INTEGER, false, -5, '-5.01'],
             [JsonBrowser::TYPE_BOOLEAN, false, true, $numberJSON],
             [JsonBrowser::TYPE_BOOLEAN, false, false, '0.00'],
             [JsonBrowser::TYPE_NULL, false, null, $numberJSON],

--- a/tests/CastTest.php
+++ b/tests/CastTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace JsonBrowser\Tests;
+
+use JsonBrowser\JsonBrowser;
+use JsonBrowser\Util;
+use JsonBrowser\Exception;
+
+/*
+ * Test type casting
+ *
+ * @package baacode/json-browser
+ * @copyright (c) 2017-2018-2018 Erayd LTD
+ * @author Steve Gilberd <steve@erayd.net>
+ * @license ISC
+ */
+class CastTest extends \PHPUnit\Framework\TestCase
+{
+    public function dataCast() : array
+    {
+        $arrayJSON = '["valueOne", "valueTwo"]';
+        $objectJSON = '{"propertyOne": "valueOne", "propertyTwo": "valueTwo"}';
+        $stringJSON = '"valueOne"';
+        $numberJSON = '5.01';
+        $integerJSON = '5';
+        $booleanJSON = 'true';
+
+        return [
+            // array casting
+            [JsonBrowser::TYPE_OBJECT, false, (object)['valueOne', 'valueTwo'], $arrayJSON],
+            [JsonBrowser::TYPE_ARRAY, true, ['valueOne', 'valueTwo'], $arrayJSON],
+            [JsonBrowser::TYPE_STRING, false, "[\n    \"valueOne\",\n    \"valueTwo\"\n]", $arrayJSON],
+            [JsonBrowser::TYPE_NUMBER, false, 2, $arrayJSON],
+            [JsonBrowser::TYPE_INTEGER, false, 2, $arrayJSON],
+            [JsonBrowser::TYPE_BOOLEAN, false, true, $arrayJSON],
+            [JsonBrowser::TYPE_BOOLEAN, false, false, '[]'],
+            [JsonBrowser::TYPE_NULL, false, null, $arrayJSON],
+
+            // object casting
+            [
+                JsonBrowser::TYPE_OBJECT,
+                true,
+                (object)['propertyOne' => 'valueOne', 'propertyTwo' => 'valueTwo'],
+                $objectJSON
+            ],
+            [JsonBrowser::TYPE_ARRAY, false, ['propertyOne' => 'valueOne', 'propertyTwo' => 'valueTwo'], $objectJSON],
+            [
+                JsonBrowser::TYPE_STRING,
+                false,
+                "{\n    \"propertyOne\": \"valueOne\",\n    \"propertyTwo\": \"valueTwo\"\n}",
+                $objectJSON
+            ],
+            [JsonBrowser::TYPE_NUMBER, false, 2, $objectJSON],
+            [JsonBrowser::TYPE_INTEGER, false, 2, $objectJSON],
+            [JsonBrowser::TYPE_BOOLEAN, false, true, $objectJSON],
+            [JsonBrowser::TYPE_BOOLEAN, false, false, '{}'],
+            [JsonBrowser::TYPE_NULL, false, null, $objectJSON],
+
+            // string casting
+            [JsonBrowser::TYPE_OBJECT, false, (object)['v', 'a', 'l', 'u', 'e', 'O', 'n', 'e'], $stringJSON],
+            [JsonBrowser::TYPE_ARRAY, false, ['v', 'a', 'l', 'u', 'e', 'O', 'n', 'e'], $stringJSON],
+            [JsonBrowser::TYPE_STRING, true, 'valueOne', $stringJSON],
+            [JsonBrowser::TYPE_NUMBER, false, 8, $stringJSON],
+            [JsonBrowser::TYPE_INTEGER, false, 8, $stringJSON],
+            [JsonBrowser::TYPE_BOOLEAN, false, true, $stringJSON],
+            [JsonBrowser::TYPE_BOOLEAN, false, false, '""'],
+            [JsonBrowser::TYPE_NULL, false, null, $stringJSON],
+
+            // number casting
+            [JsonBrowser::TYPE_OBJECT, false, (object)['value' => 5.01], $numberJSON],
+            [JsonBrowser::TYPE_ARRAY, false, [5.01], $numberJSON],
+            [JsonBrowser::TYPE_STRING, false, '5.01', $numberJSON],
+            [JsonBrowser::TYPE_NUMBER, true, 5.01, $numberJSON],
+            [JsonBrowser::TYPE_INTEGER, false, 5, $numberJSON],
+            [JsonBrowser::TYPE_BOOLEAN, false, true, $numberJSON],
+            [JsonBrowser::TYPE_BOOLEAN, false, false, '0.00'],
+            [JsonBrowser::TYPE_NULL, false, null, $numberJSON],
+
+            // integer casting
+            [JsonBrowser::TYPE_OBJECT, false, (object)['value' => 5], $integerJSON],
+            [JsonBrowser::TYPE_ARRAY, false, [5], $integerJSON],
+            [JsonBrowser::TYPE_STRING, false, '5', $integerJSON],
+            [JsonBrowser::TYPE_NUMBER, true, 5, $integerJSON],
+            [JsonBrowser::TYPE_INTEGER, true, 5, $integerJSON],
+            [JsonBrowser::TYPE_BOOLEAN, false, true, $integerJSON],
+            [JsonBrowser::TYPE_BOOLEAN, false, false, '0'],
+            [JsonBrowser::TYPE_NULL, false, null, $integerJSON],
+
+            // boolean casting
+            [JsonBrowser::TYPE_OBJECT, false, (object)['value' => true], 'true'],
+            [JsonBrowser::TYPE_ARRAY, false, [true], 'true'],
+            [JsonBrowser::TYPE_STRING, false, 'true', 'true'],
+            [JsonBrowser::TYPE_NUMBER, false, 1, 'true'],
+            [JsonBrowser::TYPE_NUMBER, false, 0, 'false'],
+            [JsonBrowser::TYPE_INTEGER, false, 1, 'true'],
+            [JsonBrowser::TYPE_INTEGER, false, 0, 'false'],
+            [JsonBrowser::TYPE_BOOLEAN, true, true, 'true'],
+            [JsonBrowser::TYPE_NULL, false, null, 'true'],
+
+            // null casting
+            [JsonBrowser::TYPE_OBJECT, false, new \stdClass(), 'null'],
+            [JsonBrowser::TYPE_ARRAY, false, [], 'null'],
+            [JsonBrowser::TYPE_STRING, false, '', 'null'],
+            [JsonBrowser::TYPE_NUMBER, false, 0, 'null'],
+            [JsonBrowser::TYPE_INTEGER, false, 0, 'null'],
+            [JsonBrowser::TYPE_BOOLEAN, false, false, 'null'],
+            [JsonBrowser::TYPE_NULL, true, null, 'null'],
+
+            // priority tests
+            [JsonBrowser::TYPE_STRING | JsonBrowser::TYPE_NUMBER, false, "[\n    \"valueOne\"\n]", '["valueOne"]'],
+            [JsonBrowser::TYPE_BOOLEAN | JsonBrowser::TYPE_INTEGER, false, 5, '5.01'],
+            [JsonBrowser::TYPE_NULL | JsonBrowser::TYPE_BOOLEAN, false, true, '5.01'],
+        ];
+    }
+
+    /** @dataProvider dataCast */
+    public function testCast(int $asType, bool $alreadyValid, $finalValue, string $json)
+    {
+        $browser = new JsonBrowser(JsonBrowser::OPT_DECODE | JsonBrowser::OPT_CAST, $json);
+
+        if (is_object($finalValue)) {
+            $this->assertSame(
+                get_object_vars($finalValue),
+                get_object_vars($browser->getValue($asType))
+            );
+        } else {
+            $this->assertSame($finalValue, $browser->getValue($asType));
+        }
+
+        if (!$alreadyValid) {
+            $this->expectException(Exception::class);
+            $browser->getValue($asType, false);
+        }
+    }
+
+    public function testGetValueAt()
+    {
+        $json = '5.01';
+        $browser = new JsonBrowser(JsonBrowser::OPT_DECODE | JsonBrowser::OPT_CAST, $json);
+
+        $this->assertSame(5, $browser->getValueAt('#/', JsonBrowser::TYPE_INTEGER));
+
+        $this->expectException(Exception::class);
+        $browser->getValueAt('#/', JsonBrowser::TYPE_INTEGER, false);
+    }
+
+    public function testUnknownType()
+    {
+        $json = 'null';
+        $browser = new JsonBrowser(JsonBrowser::OPT_DECODE | JsonBrowser::OPT_CAST, $json);
+
+        $this->expectException(Exception::class);
+        $browser->getValue(1 << 31); // there is no valid type associated with this bit
+    }
+}

--- a/tests/CastTest.php
+++ b/tests/CastTest.php
@@ -10,7 +10,7 @@ use JsonBrowser\Exception;
  * Test type casting
  *
  * @package baacode/json-browser
- * @copyright (c) 2017-2018-2018 Erayd LTD
+ * @copyright (c) 2017-2018 Erayd LTD
  * @author Steve Gilberd <steve@erayd.net>
  * @license ISC
  */

--- a/tests/ChildTest.php
+++ b/tests/ChildTest.php
@@ -9,7 +9,7 @@ use JsonBrowser\Exception;
  * Test manipulation of child nodes
  *
  * @package baacode/json-browser
- * @copyright (c) 2017-2018-2018 Erayd LTD
+ * @copyright (c) 2017-2018 Erayd LTD
  * @author Steve Gilberd <steve@erayd.net>
  * @license ISC
  */

--- a/tests/CreateTest.php
+++ b/tests/CreateTest.php
@@ -9,7 +9,7 @@ use JsonBrowser\Exception;
  * Test browser creation & node existence
  *
  * @package baacode/json-browser
- * @copyright (c) 2017-2018-2018 Erayd LTD
+ * @copyright (c) 2017-2018 Erayd LTD
  * @author Steve Gilberd <steve@erayd.net>
  * @license ISC
  */

--- a/tests/EqualityTest.php
+++ b/tests/EqualityTest.php
@@ -9,7 +9,7 @@ use JsonBrowser\Exception;
  * Test equality checks
  *
  * @package baacode/json-browser
- * @copyright (c) 2017-2018-2018 Erayd LTD
+ * @copyright (c) 2017-2018 Erayd LTD
  * @author Steve Gilberd <steve@erayd.net>
  * @license ISC
  */

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -9,7 +9,7 @@ use JsonBrowser\JsonBrowser;
  * Test exceptions
  *
  * @package baacode/json-browser
- * @copyright (c) 2017-2018-2018 Erayd LTD
+ * @copyright (c) 2017-2018 Erayd LTD
  * @author Steve Gilberd <steve@erayd.net>
  * @license ISC
  */

--- a/tests/IteratorTest.php
+++ b/tests/IteratorTest.php
@@ -9,7 +9,7 @@ use JsonBrowser\Exception;
  * Test iterator
  *
  * @package baacode/json-browser
- * @copyright (c) 2017-2018-2018 Erayd LTD
+ * @copyright (c) 2017-2018 Erayd LTD
  * @author Steve Gilberd <steve@erayd.net>
  * @license ISC
  */

--- a/tests/JSONTest.php
+++ b/tests/JSONTest.php
@@ -9,7 +9,7 @@ use JsonBrowser\Exception;
  * Test JSON encoding
  *
  * @package baacode/json-browser
- * @copyright (c) 2017-2018-2018 Erayd LTD
+ * @copyright (c) 2017-2018 Erayd LTD
  * @author Steve Gilberd <steve@erayd.net>
  * @license ISC
  */

--- a/tests/PathTest.php
+++ b/tests/PathTest.php
@@ -9,7 +9,7 @@ use JsonBrowser\Exception;
  * Test path manipulation and by-path node addressing
  *
  * @package baacode/json-browser
- * @copyright (c) 2017-2018-2018 Erayd LTD
+ * @copyright (c) 2017-2018 Erayd LTD
  * @author Steve Gilberd <steve@erayd.net>
  * @license ISC
  */

--- a/tests/RootTest.php
+++ b/tests/RootTest.php
@@ -9,7 +9,7 @@ use JsonBrowser\Exception;
  * Test getting and using a node as the root of a subtree
  *
  * @package baacode/json-browser
- * @copyright (c) 2017-2018-2018 Erayd LTD
+ * @copyright (c) 2017-2018 Erayd LTD
  * @author Steve Gilberd <steve@erayd.net>
  * @license ISC
  */

--- a/tests/SetTest.php
+++ b/tests/SetTest.php
@@ -9,7 +9,7 @@ use JsonBrowser\Exception;
  * Test setting node values
  *
  * @package baacode/json-browser
- * @copyright (c) 2017-2018-2018 Erayd LTD
+ * @copyright (c) 2017-2018 Erayd LTD
  * @author Steve Gilberd <steve@erayd.net>
  * @license ISC
  */

--- a/tests/SiblingTest.php
+++ b/tests/SiblingTest.php
@@ -9,7 +9,7 @@ use JsonBrowser\Exception;
  * Test manipulation of sibling nodes
  *
  * @package baacode/json-browser
- * @copyright (c) 2017-2018-2018 Erayd LTD
+ * @copyright (c) 2017-2018 Erayd LTD
  * @author Steve Gilberd <steve@erayd.net>
  * @license ISC
  */

--- a/tests/SubclassTest.php
+++ b/tests/SubclassTest.php
@@ -6,7 +6,7 @@ namespace JsonBrowser\Tests;
  * Test subclass identity when initial instantiation is a subclass
  *
  * @package baacode/json-browser
- * @copyright (c) 2017-2018-2018 Erayd LTD
+ * @copyright (c) 2017-2018 Erayd LTD
  * @author Steve Gilberd <steve@erayd.net>
  * @license ISC
  */

--- a/tests/TestBrowser.php
+++ b/tests/TestBrowser.php
@@ -8,7 +8,7 @@ use JsonBrowser\JsonBrowser;
  * Test subclass of JsonBrowser
  *
  * @package baacode/json-browser
- * @copyright (c) 2017-2018-2018 Erayd LTD
+ * @copyright (c) 2017-2018 Erayd LTD
  * @author Steve Gilberd <steve@erayd.net>
  * @license ISC
  */

--- a/tests/TypeTest.php
+++ b/tests/TypeTest.php
@@ -9,7 +9,7 @@ use JsonBrowser\Exception;
  * Test type checking and filtering
  *
  * @package baacode/json-browser
- * @copyright (c) 2017-2018-2018 Erayd LTD
+ * @copyright (c) 2017-2018 Erayd LTD
  * @author Steve Gilberd <steve@erayd.net>
  * @license ISC
  */


### PR DESCRIPTION
## What
 * Adds a type mask argument to `JsonBrowser::getValue()` and `JsonBrowser::getValueAt()`.
 * Adds a cast argument to `JsonBrowser::getValue()` and `JsonBrowser::getValueAt()`.
 * Adds a global option `JsonBrowser::OPT_CAST` to enable casting by default.

If the value is not of the required type, but `$cast` is true (or `JsonBrowser::OPT_CAST` is enabled), then it will be cast to one of the required types, with the minimum possible loss of data. If casting is not enabled, then an exception will be thrown. By default, casting is *not* enabled.

Any type can be cast to any other type. Some casts are lossy (e.g. casting a float to an integer, or casting a string to null). Priority is given to types which lose the least data (e.g. casting `5.88` to `JsonBrowser::TYPE_BOOLEAN | JsonBrowser::TYPE_INTEGER` will result in `5`, because an integer is a less lossy conversion than a boolean).

## Why
Because in many cases, it's important to guarantee that the value one retrieves is of a specific type or set of types, regardless of what the input type might happen to be.

## Examples
### Get a float as an integer, casting if necessary
```PHP
$int = $node->getValue(JsonBrowser::TYPE_INTEGER, true);
```

### Get an integer, ensuring that it really is an integer, but do not cast
```PHP
$int = $node->getValue(JsonBrowser::TYPE_INTEGER, false);
```

### Get a value as either a boolean or an integer, casting if necessary
```PHP
$value = $node->getValue(JsonBrowser::TYPE_BOOLEAN | JsonBrowser::TYPE_INTEGER, true);
```

### Get an integer, casting if necessary, by enabling OPT_CAST
```PHP
$browser = new JsonBrowser(JsonBrowser::OPT_DECODE | JsonBrowser::OPT_CAST, $jsonString);
$value = $browser->getValueAt('#/mynumericValue', JsonBrowser::TYPE_INTEGER);
```