### PR TITLE
Add undefined type

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -296,6 +296,11 @@ abstract class Util
             return null;
         }
 
+        // cannot cast to undefined
+        if ($asType & JsonBrowser::TYPE_UNDEFINED) {
+            throw new Exception(JsonBrowser::ERR_UNDEFINED_CAST, 'Cannot cast to undefined');
+        }
+
         // anything left over is an unknown type - should never be reached unless the user passes an invalid type
         throw new Exception(JsonBrowser::ERR_UNKNOWN_TYPE, 'Unknown value or cast type');
     }

--- a/tests/CastTest.php
+++ b/tests/CastTest.php
@@ -119,6 +119,7 @@ class CastTest extends \PHPUnit\Framework\TestCase
     {
         $browser = new JsonBrowser(JsonBrowser::OPT_DECODE | JsonBrowser::OPT_CAST, $json);
 
+        // check that cast result is as expected
         if (is_object($finalValue)) {
             $this->assertSame(
                 get_object_vars($finalValue),
@@ -128,10 +129,22 @@ class CastTest extends \PHPUnit\Framework\TestCase
             $this->assertSame($finalValue, $browser->getValue($asType));
         }
 
+        // check that casting with TYPE_ALL doesn't change anything
+        $this->assertSame($browser->getValue(), $browser->getValue(JsonBrowser::TYPE_ALL));
+
+        // check that assertion without casting works
         if (!$alreadyValid) {
             $this->expectException(Exception::class);
             $browser->getValue($asType, false);
         }
+    }
+
+    public function testPassthru()
+    {
+        $json = '5';
+        $browser = new JsonBrowser(JsonBrowser::OPT_DECODE, $json);
+
+        $this->assertSame(5, $browser->getValue(JsonBrowser::TYPE_INTEGER));
     }
 
     public function testGetValueAt()
@@ -152,5 +165,16 @@ class CastTest extends \PHPUnit\Framework\TestCase
 
         $this->expectException(Exception::class);
         $browser->getValue(1 << 31); // there is no valid type associated with this bit
+    }
+
+    public function testUndefinedType()
+    {
+        $json = 'null';
+        $browser = new JsonBrowser(JsonBrowser::OPT_DECODE | JsonBrowser::OPT_CAST, $json);
+
+        $this->assertSame(null, $browser->getChild('propertyOne')->getValue(JsonBrowser::TYPE_UNDEFINED));
+
+        $this->expectException(Exception::class);
+        $browser->getValue(JsonBrowser::TYPE_UNDEFINED);
     }
 }

--- a/tests/TypeTest.php
+++ b/tests/TypeTest.php
@@ -82,4 +82,23 @@ class TypeTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(JsonBrowser::TYPE_INTEGER, $browser->getType(true));
         $this->assertSame(JsonBrowser::TYPE_INTEGER|JsonBrowser::TYPE_NUMBER, $browser->getType(false));
     }
+
+    public function testUndefined()
+    {
+        $browser = new JsonBrowser();
+        $browser->loadJSON('{"propertyOne": "valueOne"}');
+        $propertyOne = $browser->getChild('propertyOne');
+        $propertyTwo = $browser->getChild('propertyTwo');
+
+        $this->assertSame(JsonBrowser::TYPE_STRING, $propertyOne->getType());
+
+        $this->assertSame(
+            JsonBrowser::TYPE_NULL | JsonBrowser::TYPE_UNDEFINED,
+            $propertyTwo->getType()
+        );
+
+        $this->assertSame(JsonBrowser::TYPE_UNDEFINED, $propertyTwo->getType(true));
+
+        $this->assertSame(0, $propertyTwo->getType(true) & JsonBrowser::TYPE_ALL);
+    }
 }


### PR DESCRIPTION
## What
Add `JsonBrowser::TYPE_UNDEFINED`, and use it as part of type mask operations.

## Why
Because it's useful to get the existance of a node and its type in the same operation.