### PR TITLE
Add JsonBrowser::count(), implement \Countable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ $childExists = $browser->childExists('childName');
 $child = $browser->getChild('childName');
 $child = $browser->childName; // dynamic __get() alias
 
+// count child nodes
+$numChildren = count($browser);
+$numChildren = $browser->count();
+
 // iterate through child nodes
 foreach ($browser as $childName => $childNode) {
     // $childName is the index key of the child

--- a/src/JsonBrowser.php
+++ b/src/JsonBrowser.php
@@ -14,7 +14,7 @@ use Seld\JsonLint\JsonParser;
  * @author Steve Gilberd <steve@erayd.net>
  * @license ISC
  */
-class JsonBrowser implements \IteratorAggregate
+class JsonBrowser implements \IteratorAggregate, \Countable
 {
     /** Throw exceptions instead of using NULL for nonexistent children & siblings */
     const OPT_NONEXISTENT_EXCEPTIONS = 1;
@@ -208,6 +208,22 @@ class JsonBrowser implements \IteratorAggregate
     public function childExists($key) : bool
     {
         return $this->context->valueExists(array_merge($this->path, [$key]));
+    }
+
+    /**
+     * Count the number of children contained within this node
+     *
+     * @since 2.5.0
+     *
+     * @return int The number of children within this node
+     */
+    public function count() : int
+    {
+        if ($this->isType(self::TYPE_OBJECT | self::TYPE_ARRAY)) {
+            return count($this->getValue(self::TYPE_ARRAY, true));
+        }
+
+        return 0;
     }
 
     /**

--- a/tests/CountTest.php
+++ b/tests/CountTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace JsonBrowser\Tests;
+
+use JsonBrowser\JsonBrowser;
+use JsonBrowser\Exception;
+
+/*
+ * Test counting node children
+ *
+ * @package baacode/json-browser
+ * @copyright (c) 2017-2018 Erayd LTD
+ * @author Steve Gilberd <steve@erayd.net>
+ * @license ISC
+ */
+class CountTest extends \PHPUnit\Framework\TestCase
+{
+    public function dataCount() : array
+    {
+        return [
+            [2, '[1,2]'],
+            [2, '{"propertyOne": "valueOne", "propertyTwo": "valueTwo"}'],
+            [0, '5'],
+            [0, '5.8'],
+            [0, 'true'],
+            [0, 'false'],
+            [0, '"valueOne"'],
+            [0, 'null'],
+        ];
+    }
+
+    /** @dataProvider dataCount */
+    public function testCount(int $count, string $json)
+    {
+        $browser = new JsonBrowser();
+        $browser->loadJSON($json);
+
+        $this->assertSame($count, count($browser));
+    }
+}


### PR DESCRIPTION
## What
Add JsonBrowser::count(), implement \Countable

## Why
Because manually getting the value and counting that is annoying.